### PR TITLE
Rework handle and discovery a bit

### DIFF
--- a/cmd/oidc-example-rp/main.go
+++ b/cmd/oidc-example-rp/main.go
@@ -5,8 +5,10 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/lstoll/oidc"
+	"github.com/lstoll/oidc/discovery"
 )
 
 const (
@@ -37,7 +39,11 @@ func main() {
 
 	flag.Parse()
 
-	cli, err := oidc.DiscoverClient(ctx, cfg.Issuer, cfg.ClientID, cfg.ClientSecret, cfg.RedirectURL)
+	dcl, err := discovery.NewClient(ctx, cfg.Issuer, discovery.WithBackgroundJWKSRefresh(5*time.Minute))
+	if err != nil {
+		log.Fatalf("discovering issuer: %v", err)
+	}
+	cli, err := oidc.NewClient(dcl.Metadata(), dcl.PublicHandle, cfg.ClientID, cfg.ClientSecret, cfg.RedirectURL)
 	if err != nil {
 		log.Fatalf("failed to discover issuer: %v", err)
 	}

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -1082,7 +1082,7 @@ var (
 	thMu sync.Mutex
 )
 
-func KeysetHandle(_ context.Context) (*keyset.Handle, error) {
+func KeysetHandle() *keyset.Handle {
 	thMu.Lock()
 	defer thMu.Unlock()
 	// we only make one, because it's slow
@@ -1094,5 +1094,5 @@ func KeysetHandle(_ context.Context) (*keyset.Handle, error) {
 		th = h
 	}
 
-	return th, nil
+	return th
 }

--- a/discovery/client_test.go
+++ b/discovery/client_test.go
@@ -1,0 +1,90 @@
+package discovery
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/tink-crypto/tink-go/v2/keyset"
+)
+
+func TestBackgroundRefresh(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	m := http.NewServeMux()
+	ts := httptest.NewServer(m)
+	t.Cleanup(ts.Close)
+
+	h := PublicHandle()
+	handleFn := func() *keyset.Handle {
+		return h
+	}
+
+	kh, err := NewKeysHandler(handleFn, 1*time.Nanosecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Handle("/jwks.json", kh)
+
+	pm := &ProviderMetadata{
+		Issuer:                ts.URL,
+		JWKSURI:               ts.URL + "/jwks.json",
+		AuthorizationEndpoint: "/auth",
+		TokenEndpoint:         "/token",
+	}
+
+	ch, err := NewConfigurationHandler(pm, WithCoreDefaults())
+	if err != nil {
+		t.Fatalf("error creating handler: %v", err)
+	}
+	m.Handle(oidcwk, ch)
+
+	cl, err := NewClient(ctx, ts.URL, WithBackgroundJWKSRefresh(1*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// capture the original keys
+	origKIDs := getKIDs(cl.PublicHandle())
+
+	// set the handle to a new set, let it get refreshed.
+	h = PublicHandle()
+	time.Sleep(5 * time.Millisecond)
+
+	newKIDs := getKIDs(cl.PublicHandle()) // on the block
+
+	if reflect.DeepEqual(origKIDs, newKIDs) {
+		t.Errorf("keys did not refresh, orig: %v new: %v", origKIDs, newKIDs)
+	}
+
+	// discard our reference to the client, and force a GC. The GC should stop
+	// the background refresh.
+	refresher := cl.refresher
+	if refresher.stopped {
+		t.Error("refresher should not be stopped after GC")
+	}
+
+	cl = nil
+	runtime.GC()
+
+	time.Sleep(5 * time.Millisecond)
+
+	if !refresher.stopped {
+		t.Error("refresher should be stopped after GC")
+	}
+}
+
+func getKIDs(h *keyset.Handle) []int {
+	var ret []int
+	for _, ki := range h.KeysetInfo().KeyInfo {
+		ret = append(ret, int(ki.KeyId))
+	}
+	return ret
+}

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -12,20 +12,22 @@ import (
 	"github.com/tink-crypto/tink-go/v2/keyset"
 )
 
-func PublicHandle(ctx context.Context) (*keyset.Handle, error) {
+func PublicHandle() *keyset.Handle {
 	h, err := keyset.NewHandle(jwt.RS256_2048_F4_Key_Template())
 	if err != nil {
-		return nil, fmt.Errorf("creating handle: %v", err)
+		panic(fmt.Sprintf("creating handle: %v", err))
 	}
 	h, err = h.Public()
 	if err != nil {
-		return nil, fmt.Errorf("getting public handle: %w", err)
+		panic(fmt.Sprintf("getting public handle: %v", err))
 	}
 
-	return h, nil
+	return h
 }
 
 func TestDiscovery(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -51,13 +53,8 @@ func TestDiscovery(t *testing.T) {
 	}
 	m.Handle(oidcwk, ch)
 
-	cli, err := NewClient(ctx, ts.URL)
+	_, err = NewClient(ctx, ts.URL)
 	if err != nil {
 		t.Fatalf("failed to create discovery client: %v", err)
-	}
-
-	_, err = cli.PublicHandle(ctx)
-	if err != nil {
-		t.Fatalf("getting public handle: %v", err)
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -151,7 +151,7 @@ func TestE2E(t *testing.T) {
 			}
 			mux.Handle("/.well-known/openid-configuration/", discoh)
 
-			privh, err := KeysetHandle(ctx)
+			privh := KeysetHandle()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -167,7 +167,11 @@ func TestE2E(t *testing.T) {
 			mux.Handle("/jwks.json", jwksh)
 
 			// set up client
-			cl, err := oidc.DiscoverClient(ctx, oidcSvr.URL, clientID, clientSecret, cliSvr.URL)
+			dcl, err := discovery.NewClient(ctx, oidcSvr.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cl, err := oidc.NewClient(dcl.Metadata(), dcl.PublicHandle, clientID, clientSecret, cliSvr.URL)
 			if err != nil {
 				t.Fatalf("discovering client: %v", err)
 			}
@@ -326,7 +330,7 @@ var (
 	thMu sync.Mutex
 )
 
-func KeysetHandle(_ context.Context) (*keyset.Handle, error) {
+func KeysetHandle() *keyset.Handle {
 	thMu.Lock()
 	defer thMu.Unlock()
 	// we only make one, because it's slow
@@ -338,5 +342,5 @@ func KeysetHandle(_ context.Context) (*keyset.Handle, error) {
 		th = h
 	}
 
-	return th, nil
+	return th
 }


### PR DESCRIPTION
Handles taking context/returning errors is a bit annoying, they should always just have a handle. So change the interface to do that. The network access stuff was a throwback to where we'd lookup keys by their ID, and load them on demand. That was bad though as it makes for a bit of a DoS vector when you send fake JWTs with made up IDs. This moves to a periodic, intentional keyset fetch.

Update discovery to manage refreshing itself, either via manual calls or optionally spawning a background routine.