### PR TITLE
Use JWTs for access tokens

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -422,3 +422,12 @@ func (c *AccessTokenClaims) Unmarshal(into any) error {
 	}
 	return json.Unmarshal(c.raw, into)
 }
+
+func (c AccessTokenClaims) String() string {
+	m, err := json.Marshal(&c)
+	if err != nil {
+		return fmt.Sprintf("sub: %s failed: %v", c.Subject, err)
+	}
+
+	return string(m)
+}

--- a/claims.go
+++ b/claims.go
@@ -3,16 +3,17 @@ package oidc
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
 	"github.com/tink-crypto/tink-go/v2/jwt"
 )
 
-// Claims represents the set of JWT claims for the user.
+// IDClaims represents the set of JWT claims for a user ID Token.
 //
-// https://openid.net/specs/openid-connect-core-1_0.html#Claims
-type Claims struct {
+// https://openid.net/specs/openid-connect-core-1_0.html#IDClaims
+type IDClaims struct {
 	// REQUIRED. Issuer Identifier for the Issuer of the response. The iss value
 	// is a case sensitive URL using the https scheme that contains scheme,
 	// host, and optionally, port number and path components and no query or
@@ -27,7 +28,7 @@ type Claims struct {
 	// REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain
 	// the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY
 	// also contain identifiers for other audiences.
-	Audience Audience `json:"aud,omitempty"`
+	Audience StrOrSlice `json:"aud,omitempty"`
 	// REQUIRED. Expiration time on or after which the ID Token MUST NOT be
 	// accepted for processing. The processing of this parameter requires that
 	// the current date/time MUST be before the expiration date/time listed in
@@ -96,13 +97,13 @@ type Claims struct {
 
 	// Extra are additional claims, that the standard claims will be merged in
 	// to. If a key is overridden here, the struct value wins.
-	Extra map[string]interface{} `json:"-"`
+	Extra map[string]any `json:"-"`
 
 	// keep the raw data here, so we can unmarshal in to custom structs
 	raw json.RawMessage
 }
 
-func (c Claims) String() string {
+func (c IDClaims) String() string {
 	m, err := json.Marshal(&c)
 	if err != nil {
 		return fmt.Sprintf("sub: %s failed: %v", c.Subject, err)
@@ -111,9 +112,9 @@ func (c Claims) String() string {
 	return string(m)
 }
 
-func (c Claims) MarshalJSON() ([]byte, error) {
+func (c IDClaims) MarshalJSON() ([]byte, error) {
 	// avoid recursing on this method
-	type ids Claims
+	type ids IDClaims
 	id := ids(c)
 
 	sj, err := json.Marshal(&id)
@@ -121,12 +122,12 @@ func (c Claims) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	sm := map[string]interface{}{}
+	sm := map[string]any{}
 	if err := json.Unmarshal(sj, &sm); err != nil {
 		return nil, err
 	}
 
-	om := map[string]interface{}{}
+	om := map[string]any{}
 
 	for k, v := range c.Extra {
 		om[k] = v
@@ -139,15 +140,15 @@ func (c Claims) MarshalJSON() ([]byte, error) {
 	return json.Marshal(om)
 }
 
-func (c *Claims) UnmarshalJSON(b []byte) error {
-	type ids Claims
+func (c *IDClaims) UnmarshalJSON(b []byte) error {
+	type ids IDClaims
 	id := ids{}
 
 	if err := json.Unmarshal(b, &id); err != nil {
 		return err
 	}
 
-	em := map[string]interface{}{}
+	em := map[string]any{}
 
 	if err := json.Unmarshal(b, &em); err != nil {
 		return err
@@ -165,13 +166,13 @@ func (c *Claims) UnmarshalJSON(b []byte) error {
 
 	id.raw = b
 
-	*c = Claims(id)
+	*c = IDClaims(id)
 
 	return nil
 }
 
 // Unmarshal unpacks the raw JSON data from this token into the passed type.
-func (c *Claims) Unmarshal(into interface{}) error {
+func (c *IDClaims) Unmarshal(into any) error {
 	if c.raw == nil {
 		// gracefully handle the weird case where the user might want to call
 		// this on a struct of their own creation, rather than one retrieved
@@ -185,28 +186,24 @@ func (c *Claims) Unmarshal(into interface{}) error {
 	return json.Unmarshal(c.raw, into)
 }
 
-// Audience represents a OIDC ID Token's Audience field.
-type Audience []string
+// StrOrSlice represents a JWT claim that can either be a single string, or a
+// list of strings..
+type StrOrSlice []string
 
-// Contains returns true if a passed audence is found in the token's set
-func (a Audience) Contains(aud string) bool {
-	for _, ia := range a {
-		if ia == aud {
-			return true
-		}
-	}
-	return false
+// Contains returns true if a passed item is found in the set
+func (a StrOrSlice) Contains(s string) bool {
+	return slices.Contains(a, s)
 }
 
-func (a Audience) MarshalJSON() ([]byte, error) {
+func (a StrOrSlice) MarshalJSON() ([]byte, error) {
 	if len(a) == 1 {
 		return json.Marshal(a[0])
 	}
 	return json.Marshal([]string(a))
 }
 
-func (a *Audience) UnmarshalJSON(b []byte) error {
-	var ua interface{}
+func (a *StrOrSlice) UnmarshalJSON(b []byte) error {
+	var ua any
 	if err := json.Unmarshal(b, &ua); err != nil {
 		return err
 	}
@@ -214,7 +211,7 @@ func (a *Audience) UnmarshalJSON(b []byte) error {
 	switch ja := ua.(type) {
 	case string:
 		*a = []string{ja}
-	case []interface{}:
+	case []any:
 		aa := make([]string, len(ja))
 		for i, ia := range ja {
 			sa, ok := ia.(string)
@@ -259,15 +256,141 @@ func (u *UnixTime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func claimsFromVerifiedJWT(jwt *jwt.VerifiedJWT) (*Claims, error) {
+func claimsFromVerifiedJWT(jwt *jwt.VerifiedJWT) (*IDClaims, error) {
 	// TODO(lstoll) is this good enough? Do we want to do more/other processing?
 	b, err := jwt.JSONPayload()
 	if err != nil {
 		return nil, fmt.Errorf("extracting JSON payload: %w", err)
 	}
-	var cl Claims
+	var cl IDClaims
 	if err := json.Unmarshal(b, &cl); err != nil {
 		return nil, fmt.Errorf("unmarshaling claims: %w", err)
 	}
 	return &cl, nil
+}
+
+// AccessTokenClaims represents the set of JWT claims for an OAuth2 JWT Access
+// token.
+//
+// https://datatracker.ietf.org/doc/html/rfc9068
+type AccessTokenClaims struct {
+	// REQUIRED. https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1
+	Issuer string `json:"iss,omitempty"`
+	// REQUIRED. https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4
+	Expiry UnixTime `json:"exp,omitempty"`
+	// REQUIRED. https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3
+	Audience StrOrSlice `json:"aud,omitempty"`
+	// REQUIRED - as defined in Section 4.1.2 of [RFC7519]. In cases
+	// of access tokens obtained through grants where a resource owner is
+	// involved, such as the authorization code grant, the value of "sub" SHOULD
+	// correspond to the subject identifier of the resource owner. In cases of
+	// access tokens obtained through grants where no resource owner is
+	// involved, such as the client credentials grant, the value of "sub" SHOULD
+	// correspond to an identifier the authorization server uses to indicate the
+	// client application. See Section 5 for more details on this scenario.
+	// Also, see Section 6 for a discussion about how different choices in
+	// assigning "sub" values can impact privacy.
+	// https://www.rfc-editor.org/rfc/rfc7519#section-4.1.2
+	Subject string `json:"sub,omitempty"`
+	// REQUIRED. https://www.rfc-editor.org/rfc/rfc8693#section-4.3
+	ClientID string `json:"client_id,omitempty"`
+	// REQUIRED. https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6
+	IssuedAt UnixTime `json:"iat,omitempty"`
+	// REQUIRED. https://www.rfc-editor.org/rfc/rfc7519#section-4.1.7
+	JWTID string `json:"jti,omitempty"`
+	// https://www.rfc-editor.org/rfc/rfc8693#section-4.2
+	Scope string `json:"scope,omitempty"`
+	// https://datatracker.ietf.org/doc/html/rfc9068#section-2.2.3.1 |
+	// https://www.rfc-editor.org/rfc/rfc7643#section-4.1.2
+	//
+	// TODO(lstoll) - do we want to support the more complex than a list version
+	// of these, i.e https://www.rfc-editor.org/rfc/rfc7643#section-8.2 ?
+	Groups []string `json:"groups,omitempty"`
+	// https://datatracker.ietf.org/doc/html/rfc9068#section-2.2.3.1 |
+	// https://www.rfc-editor.org/rfc/rfc7643#section-4.1.2
+	Roles []string `json:"roles,omitempty"`
+	// https://datatracker.ietf.org/doc/html/rfc9068#section-2.2.3.1 |
+	// https://www.rfc-editor.org/rfc/rfc7643#section-4.1.2
+	Entitlements []string `json:"entitlements,omitempty"`
+
+	// Extra are additional claims, that the standard claims will be merged in
+	// to. If a key is overridden here, the struct value wins.
+	Extra map[string]any `json:"-"`
+
+	// keep the raw data here, so we can unmarshal in to custom structs
+	raw json.RawMessage
+}
+
+func (c AccessTokenClaims) MarshalJSON() ([]byte, error) {
+	// avoid recursing on this method
+	type ids AccessTokenClaims
+	id := ids(c)
+
+	sj, err := json.Marshal(&id)
+	if err != nil {
+		return nil, err
+	}
+
+	sm := map[string]any{}
+	if err := json.Unmarshal(sj, &sm); err != nil {
+		return nil, err
+	}
+
+	om := map[string]any{}
+
+	for k, v := range c.Extra {
+		om[k] = v
+	}
+
+	for k, v := range sm {
+		om[k] = v
+	}
+
+	return json.Marshal(om)
+}
+
+func (c *AccessTokenClaims) UnmarshalJSON(b []byte) error {
+	type ids AccessTokenClaims
+	id := ids{}
+
+	if err := json.Unmarshal(b, &id); err != nil {
+		return err
+	}
+
+	em := map[string]any{}
+
+	if err := json.Unmarshal(b, &em); err != nil {
+		return err
+	}
+
+	for _, f := range []string{
+		"iss", "sub", "aud", "exp", "iat", "client_id", "jti", "scope", "groups", "roles", "entitlements",
+	} {
+		delete(em, f)
+	}
+
+	if len(em) > 0 {
+		id.Extra = em
+	}
+
+	id.raw = b
+
+	*c = AccessTokenClaims(id)
+
+	return nil
+}
+
+// Unmarshal unpacks the raw JSON data from this token into the passed type.
+func (c *AccessTokenClaims) Unmarshal(into any) error {
+	if c.raw == nil {
+		// gracefully handle the weird case where the user might want to call
+		// this on a struct of their own creation, rather than one retrieved
+		// from a remote source
+		b, err := json.Marshal(c)
+		if err != nil {
+			return err
+		}
+		c.raw = b
+	}
+	return json.Unmarshal(c.raw, into)
 }

--- a/claims_test.go
+++ b/claims_test.go
@@ -12,14 +12,14 @@ import (
 func TestIDTokenMarshaling(t *testing.T) {
 	for _, tc := range []struct {
 		Name     string
-		Token    Claims
+		Token    any
 		WantJSON string
 	}{
 		{
 			Name: "basic",
-			Token: Claims{
+			Token: IDClaims{
 				Issuer:   "http://issuer",
-				Audience: Audience{"aud"},
+				Audience: StrOrSlice{"aud"},
 				Expiry:   NewUnixTime(mustTime(time.Parse("2006-Jan-02", "2019-Nov-20"))),
 				Extra: map[string]interface{}{
 					"hello": "world",
@@ -34,8 +34,8 @@ func TestIDTokenMarshaling(t *testing.T) {
 		},
 		{
 			Name: "multiple audiences",
-			Token: Claims{
-				Audience: Audience{"aud1", "aud2"},
+			Token: IDClaims{
+				Audience: StrOrSlice{"aud1", "aud2"},
 			},
 			WantJSON: `{
   "aud": [
@@ -46,7 +46,7 @@ func TestIDTokenMarshaling(t *testing.T) {
 		},
 		{
 			Name: "extra shouldn't shadow primary fields",
-			Token: Claims{
+			Token: IDClaims{
 				Issuer: "http://issuer",
 				Extra: map[string]interface{}{
 					"iss": "http://bad",
@@ -58,10 +58,10 @@ func TestIDTokenMarshaling(t *testing.T) {
 		},
 		{
 			Name: "complex extra",
-			Token: Claims{
+			Token: IDClaims{
 				Issuer:   "http://127.0.0.1:62281",
 				Subject:  "CgVmb29pZBIEbW9jaw",
-				Audience: Audience{"testclient"},
+				Audience: StrOrSlice{"testclient"},
 				Expiry:   1576187854,
 				IssuedAt: 1576187824,
 				AuthTime: 1576187824,
@@ -86,6 +86,36 @@ func TestIDTokenMarshaling(t *testing.T) {
   "username": "foo"
 }`,
 		},
+		{
+			Name: "complex access token",
+			Token: AccessTokenClaims{
+				Issuer:   "http://127.0.0.1:62281",
+				Subject:  "CgVmb29pZBIEbW9jaw",
+				Audience: StrOrSlice{"testclient"},
+				Expiry:   1576187854,
+				IssuedAt: 1576187824,
+				JWTID:    "b91d9d40-009d-42ae-afe1-9d323c664950",
+				Extra: map[string]interface{}{
+					"email":    "foo@bar.com",
+					"groups":   []string{"foo", "bar"},
+					"username": "foo",
+				},
+			},
+			WantJSON: `{
+  "aud": "testclient",
+  "email": "foo@bar.com",
+  "exp": 1576187854,
+  "groups": [
+    "foo",
+    "bar"
+  ],
+  "iat": 1576187824,
+  "iss": "http://127.0.0.1:62281",
+  "jti": "b91d9d40-009d-42ae-afe1-9d323c664950",
+  "sub": "CgVmb29pZBIEbW9jaw",
+  "username": "foo"
+}`,
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			jb, err := json.MarshalIndent(tc.Token, "", "  ")
@@ -104,7 +134,7 @@ func TestIDTokenUnmarshaling(t *testing.T) {
 	for _, tc := range []struct {
 		Name      string
 		JSON      string
-		WantToken Claims
+		WantToken IDClaims
 	}{
 		{
 			Name: "basic",
@@ -114,9 +144,9 @@ func TestIDTokenUnmarshaling(t *testing.T) {
   "hello": "world",
   "iss": "http://issuer"
 }`,
-			WantToken: Claims{
+			WantToken: IDClaims{
 				Issuer:   "http://issuer",
-				Audience: Audience{"aud"},
+				Audience: StrOrSlice{"aud"},
 				Expiry:   NewUnixTime(mustTime(time.Parse("2006-Jan-02", "2019-Nov-20"))),
 				Extra: map[string]interface{}{
 					"hello": "world",
@@ -128,8 +158,8 @@ func TestIDTokenUnmarshaling(t *testing.T) {
 			JSON: `{
   "aud": ["aud1", "aud2"]
 }`,
-			WantToken: Claims{
-				Audience: Audience{"aud1", "aud2"},
+			WantToken: IDClaims{
+				Audience: StrOrSlice{"aud1", "aud2"},
 			},
 		},
 		{
@@ -140,9 +170,9 @@ func TestIDTokenUnmarshaling(t *testing.T) {
   "hello": "world",
   "iss": "http://issuer"
 }`,
-			WantToken: Claims{
+			WantToken: IDClaims{
 				Issuer:   "http://issuer",
-				Audience: Audience{"aud"},
+				Audience: StrOrSlice{"aud"},
 				Expiry:   1601386279,
 				Extra: map[string]interface{}{
 					"hello": "world",
@@ -151,12 +181,12 @@ func TestIDTokenUnmarshaling(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			tok := Claims{}
+			tok := IDClaims{}
 			if err := json.Unmarshal([]byte(tc.JSON), &tok); err != nil {
 				t.Fatalf("Unexpected error unmarshaling JSON: %v", err)
 			}
 
-			if diff := cmp.Diff(tc.WantToken, tok, cmpopts.IgnoreUnexported(Claims{})); diff != "" {
+			if diff := cmp.Diff(tc.WantToken, tok, cmpopts.IgnoreUnexported(IDClaims{})); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/cmd/oidc-example-op/main.go
+++ b/cmd/oidc-example-op/main.go
@@ -24,15 +24,16 @@ func main() {
 		log.Fatalf("parsing clients: %v", err)
 	}
 
+	iss := "http://localhost:8085"
+
 	core, err := core.New(&core.Config{
+		Issuer:           iss,
 		AuthValidityTime: 5 * time.Minute,
 		CodeValidityTime: 5 * time.Minute,
 	}, smgr, clients, core.StaticKeysetHandle(privh))
 	if err != nil {
 		log.Fatalf("Failed to create OIDC server instance: %v", err)
 	}
-
-	iss := "http://localhost:8085"
 
 	m := http.NewServeMux()
 

--- a/cmd/oidc-example-op/server.go
+++ b/cmd/oidc-example-op/server.go
@@ -121,13 +121,14 @@ func (s *server) token(w http.ResponseWriter, req *http.Request) {
 		meta := s.storage.sessions[tr.SessionID].Meta
 		s.storage.sessions[tr.SessionID].Meta = meta
 
-		idt := tr.PrefillIDToken("http://localhost:8085", "subject", time.Now().Add(s.tokenValidFor))
+		idt := tr.PrefillIDToken("subject", time.Now().Add(s.tokenValidFor))
+		at := tr.PrefillAccessToken("subject", time.Now().Add(s.tokenValidFor))
 
 		return &core.TokenResponse{
-			AccessTokenValidUntil:  time.Now().Add(s.tokenValidFor),
 			RefreshTokenValidUntil: time.Now().Add(s.refreshValidFor),
 			IssueRefreshToken:      tr.SessionRefreshable, // always allow it if we want it
 			IDToken:                idt,
+			AccessToken:            at,
 		}, nil
 	})
 	if err != nil {

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lstoll/oidc"
 	"github.com/lstoll/oidc/oauth2"
 	"github.com/tink-crypto/tink-go/v2/jwt"
@@ -57,6 +58,8 @@ const (
 
 // Config sets configuration values for the OIDC flow implementation
 type Config struct {
+	// Issuer is the issuer we are serving for.
+	Issuer string
 	// AuthValidityTime is the maximum time an authorization flow/AuthID is
 	// valid. This is the time from Starting to Finishing the authorization. The
 	// optimal time here will be application specific, and should encompass how
@@ -73,6 +76,7 @@ type OIDCOpt func(*OIDC)
 
 // OIDC can be used to handle the various parts of the OIDC auth flow.
 type OIDC struct {
+	issuer   string
 	smgr     SessionManager
 	clients  ClientSource
 	handleFn KeysetHandleFunc
@@ -84,11 +88,16 @@ type OIDC struct {
 }
 
 func New(cfg *Config, smgr SessionManager, clientSource ClientSource, signer KeysetHandleFunc, opts ...OIDCOpt) (*OIDC, error) {
+	if cfg.Issuer == "" {
+		return nil, fmt.Errorf("issuer must be provided")
+	}
+
 	o := &OIDC{
 		smgr:     smgr,
 		clients:  clientSource,
 		handleFn: signer,
 
+		issuer:           cfg.Issuer,
 		authValidityTime: cfg.AuthValidityTime,
 		codeValidityTime: cfg.CodeValidityTime,
 
@@ -328,6 +337,7 @@ type TokenRequest struct {
 	// AuthTime Time when the End-User authentication occurred
 	AuthTime time.Time
 
+	issuer  string
 	authReq *sessAuthRequest
 	now     func() time.Time
 }
@@ -344,9 +354,9 @@ type TokenRequest struct {
 // * Issued At (iat) time set
 // * Auth Time (auth_time) time set
 // * Nonce that was originally passed in, if there was one
-func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.IDClaims {
+func (t *TokenRequest) PrefillIDToken(sub string, expires time.Time) oidc.IDClaims {
 	return oidc.IDClaims{
-		Issuer:   iss,
+		Issuer:   t.issuer,
 		Subject:  sub,
 		Expiry:   oidc.NewUnixTime(expires),
 		Audience: oidc.StrOrSlice{t.ClientID},
@@ -359,11 +369,50 @@ func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.I
 	}
 }
 
+// PrefillAccessToken can be used to create a basic access token containing all
+// required claims, mapped with information from this request. The issuer and
+// subject will be set as provided, and the token's expiry will be set to the
+// appropriate time base on the validity period
+//
+// Aside from the explicitly passed fields, the following information will be set:
+// * Audience (aud) will contain the Client ID
+// * ACR claim set
+// * AMR claim set
+// * Issued At (iat) time set
+// * Auth Time (auth_time) time set
+// * Scope from the Authorization
+// * Randomly generated JWTID (uuid v4)
+// * Client ID for this request
+func (t *TokenRequest) PrefillAccessToken(sub string, expires time.Time) oidc.AccessTokenClaims {
+	return oidc.AccessTokenClaims{
+		Issuer:         t.issuer,
+		Subject:        sub,
+		Expiry:         oidc.NewUnixTime(expires),
+		Audience:       oidc.StrOrSlice{t.ClientID},
+		ACR:            t.Authorization.ACR,
+		AMR:            t.Authorization.AMR,
+		IssuedAt:       oidc.NewUnixTime(t.now()),
+		AuthTime:       oidc.NewUnixTime(t.AuthTime),
+		Scope:          strings.Join(t.Authorization.Scopes, " "),
+		JWTID:          uuid.NewString(),
+		ClientID:       t.ClientID,
+		LoginSessionID: t.SessionID,
+		Extra:          map[string]interface{}{},
+	}
+}
+
 // TokenResponse is returned by the token endpoint handler, indicating what it
 // should actually return to the user.
 type TokenResponse struct {
 	// IssueRefreshToken indicates if we should issue a refresh token.
 	IssueRefreshToken bool
+
+	// AccessToken is returned as the access token for the request to this
+	// endpoint. It is up to the application to store _all_ the desired
+	// information in the token correctly, and to obey the OAuth2 JWT profile
+	// spec (https://datatracker.ietf.org/doc/html/rfc9068). The handler will
+	// make no changes to this token.
+	AccessToken oidc.AccessTokenClaims
 
 	// IDToken is returned as the id_token for the request to this endpoint. It
 	// is up to the application to store _all_ the desired information in the
@@ -371,9 +420,6 @@ type TokenResponse struct {
 	// changes to this token.
 	IDToken oidc.IDClaims
 
-	// AccessTokenValidUntil indicates how long the returned authorization token
-	// should be valid for.
-	AccessTokenValidUntil time.Time
 	// RefreshTokenValidUntil indicates how long the returned refresh token should
 	// be valid for, assuming one is issued.
 	RefreshTokenValidUntil time.Time
@@ -502,6 +548,7 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		Nonce:              sess.Request.Nonce,
 		AuthTime:           sess.Authorization.AuthorizedAt,
 
+		issuer:  o.issuer,
 		authReq: sess.Request,
 		now:     o.now,
 	}
@@ -519,26 +566,8 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "id token cannot have a 0 expiry"}
 	}
 
-	if tresp.AccessTokenValidUntil.Before(o.now()) {
-		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "access token must be valid > now"}
-	}
-
 	if tresp.IssueRefreshToken && tresp.RefreshTokenValidUntil.Before(o.now()) {
 		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "refresh token must be valid > now"}
-	}
-
-	// create a new access token
-	useratok, satok, err := newToken(sess.ID, tresp.AccessTokenValidUntil)
-	if err != nil {
-		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "failed to generate access token", Cause: err}
-	}
-	sess.Expiry = satok.Expiry
-	sess.AccessToken = satok
-	sess.Stage = sessionStageAccessTokenIssued
-
-	accessTok, err := marshalToken(useratok)
-	if err != nil {
-		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "failed to marshal user token", Cause: err}
 	}
 
 	// If we're allowing refresh, issue one of those too.
@@ -571,21 +600,31 @@ func (o *OIDC) token(ctx context.Context, req *tokenRequest, handler func(req *T
 		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "creating signer from handle", Cause: err}
 	}
 
-	rawJWT, err := claimsToRawJWT(tresp.IDToken)
+	rawIDJWT, err := idClaimsToRawJWT(tresp.IDToken)
 	if err != nil {
-		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "mapping claims to jwt", Cause: err}
+		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "mapping id claims to jwt", Cause: err}
 	}
 
-	sidt, err := signer.SignAndEncode(rawJWT)
+	sidt, err := signer.SignAndEncode(rawIDJWT)
 	if err != nil {
 		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "failed to sign id token", Cause: err}
 	}
 
+	rawATJWT, err := accessTokenClaimsToRawJWT(tresp.AccessToken)
+	if err != nil {
+		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "mapping access claims to jwt", Cause: err}
+	}
+
+	sat, err := signer.SignAndEncode(rawATJWT)
+	if err != nil {
+		return nil, &httpError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "failed to sign access token", Cause: err}
+	}
+
 	return &tokenResponse{
-		AccessToken:  accessTok,
+		AccessToken:  sat,
 		RefreshToken: refreshTok,
 		TokenType:    "bearer",
-		ExpiresIn:    tresp.AccessTokenValidUntil.Sub(o.now()),
+		ExpiresIn:    tresp.AccessToken.Expiry.Time().Sub(o.now()),
 		ExtraParams: map[string]interface{}{
 			"id_token": string(sidt),
 		},
@@ -681,8 +720,8 @@ func (o *OIDC) fetchRefreshSession(ctx context.Context, treq *tokenRequest) (*se
 // UserinfoRequest contains information about this request to the UserInfo
 // endpoint
 type UserinfoRequest struct {
-	// SessionID of the session this request is for.
-	SessionID string
+	// Subject is the sub of the user this request is for.
+	Subject string
 }
 
 // Userinfo can handle a request to the userinfo endpoint. If the request is not
@@ -700,54 +739,44 @@ func (o *OIDC) Userinfo(w http.ResponseWriter, req *http.Request, handler func(w
 		return herr
 	}
 
-	uaccess, err := unmarshalToken(authSp[1])
+	h := o.handleFn()
+	ph, err := h.Public()
 	if err != nil {
-		be := &bearerError{Code: bearerErrorCodeInvalidRequest, Description: "malformed token"}
+		herr := &httpError{Code: http.StatusInternalServerError, Cause: err}
+		_ = writeError(w, req, herr)
+		return herr
+	}
+
+	jwtVerifier, err := jwt.NewVerifier(ph)
+	if err != nil {
+		herr := &httpError{Code: http.StatusInternalServerError, Cause: err}
+		_ = writeError(w, req, herr)
+		return herr
+	}
+
+	jwtValidator, err := jwt.NewValidator(&jwt.ValidatorOpts{
+		ExpectedIssuer:  &o.issuer,
+		IgnoreAudiences: true, // we don't care about the audience here, this is just introspecting the user
+	})
+
+	jwt, err := jwtVerifier.VerifyAndDecode(authSp[1], jwtValidator)
+	if err != nil {
+		be := &bearerError{Code: bearerErrorCodeInvalidRequest, Description: "invalid access token"}
 		herr := &httpError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), Cause: err}
 		_ = writeError(w, req, herr)
 		return herr
 	}
 
-	// make sure we have an unexpired session
-	sess, err := getSession(req.Context(), o.smgr, uaccess.SessionId)
+	sub, err := jwt.Subject()
 	if err != nil {
 		herr := &httpError{Code: http.StatusInternalServerError, Cause: err}
-		_ = writeError(w, req, herr)
-		return herr
-	}
-
-	// make sure we have a valid, unexpired session and an unexpired token
-	if sess == nil || o.now().After(sess.Expiry) || o.now().After(sess.AccessToken.Expiry) {
-		be := &bearerError{Code: bearerErrorCodeInvalidToken, Description: "token no longer valid"}
-		herr := &httpError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), CauseMsg: "Access token expired"}
-		_ = writeError(w, req, herr)
-		return herr
-	}
-
-	// and make sure the token is valid
-	ok, err := tokensMatch(uaccess, sess.AccessToken)
-	if err != nil {
-		herr := &httpError{Code: http.StatusInternalServerError, Cause: err}
-		_ = writeError(w, req, herr)
-		return herr
-	}
-	if !ok {
-		// if we're passed an invalid access token drop the whole session, might
-		// be under attack
-		if err := o.smgr.DeleteSession(req.Context(), sess.ID); err != nil {
-			herr := &httpError{Code: http.StatusInternalServerError, Cause: err}
-			_ = writeError(w, req, herr)
-			return herr
-		}
-		be := &bearerError{Code: bearerErrorCodeInvalidToken, Description: "token not valid"}
-		herr := &httpError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String()}
 		_ = writeError(w, req, herr)
 		return herr
 	}
 
 	// If we make it to here, we have been presented a valid token for a valid session. Run the handler.
 	uireq := &UserinfoRequest{
-		SessionID: uaccess.SessionId,
+		Subject: sub,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -778,7 +807,7 @@ func verifyCodeChallenge(codeVerifier, storedCodeChallenge string) bool {
 	return computedChallenge == storedCodeChallenge
 }
 
-func claimsToRawJWT(claims oidc.IDClaims) (*jwt.RawJWT, error) {
+func idClaimsToRawJWT(claims oidc.IDClaims) (*jwt.RawJWT, error) {
 	var exp *time.Time
 	if claims.Expiry != 0 {
 		t := claims.Expiry.Time()
@@ -819,6 +848,68 @@ func claimsToRawJWT(claims oidc.IDClaims) (*jwt.RawJWT, error) {
 	if claims.AZP != "" {
 		opts.CustomClaims["azp"] = claims.AZP
 	}
+	for k, v := range claims.Extra {
+		opts.CustomClaims[k] = v
+	}
+
+	raw, err := jwt.NewRawJWT(opts)
+	if err != nil {
+		return nil, fmt.Errorf("constructing raw JWT from claims: %w", err)
+	}
+
+	return raw, nil
+}
+
+func accessTokenClaimsToRawJWT(claims oidc.AccessTokenClaims) (*jwt.RawJWT, error) {
+	var exp *time.Time
+	if claims.Expiry != 0 {
+		t := claims.Expiry.Time()
+		exp = &t
+	}
+	var iat *time.Time
+	if claims.IssuedAt != 0 {
+		t := claims.IssuedAt.Time()
+		iat = &t
+	}
+	var jti *string
+	if claims.JWTID != "" {
+		jti = &claims.JWTID
+	}
+
+	opts := &jwt.RawJWTOptions{
+		Issuer:       &claims.Issuer,
+		Subject:      &claims.Subject,
+		Audiences:    claims.Audience,
+		ExpiresAt:    exp,
+		IssuedAt:     iat,
+		JWTID:        jti,
+		CustomClaims: map[string]interface{}{},
+	}
+	if claims.AuthTime != 0 {
+		opts.CustomClaims["auth_time"] = int(claims.AuthTime)
+	}
+	if claims.ACR != "" {
+		opts.CustomClaims["acr"] = claims.ACR
+	}
+	if claims.AMR != nil {
+		opts.CustomClaims["amr"] = claims.AMR
+	}
+	if claims.ClientID != "" {
+		opts.CustomClaims["client_id"] = claims.ClientID
+	}
+	if claims.Scope != "" {
+		opts.CustomClaims["scope"] = claims.Scope
+	}
+	if len(claims.Groups) != 0 {
+		opts.CustomClaims["groups"] = claims.Groups
+	}
+	if len(claims.Roles) != 0 {
+		opts.CustomClaims["roles"] = claims.Roles
+	}
+	if len(claims.Entitlements) != 0 {
+		opts.CustomClaims["entitlements"] = claims.Entitlements
+	}
+
 	for k, v := range claims.Extra {
 		opts.CustomClaims[k] = v
 	}

--- a/core/oidc.go
+++ b/core/oidc.go
@@ -344,12 +344,12 @@ type TokenRequest struct {
 // * Issued At (iat) time set
 // * Auth Time (auth_time) time set
 // * Nonce that was originally passed in, if there was one
-func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.Claims {
-	return oidc.Claims{
+func (t *TokenRequest) PrefillIDToken(iss, sub string, expires time.Time) oidc.IDClaims {
+	return oidc.IDClaims{
 		Issuer:   iss,
 		Subject:  sub,
 		Expiry:   oidc.NewUnixTime(expires),
-		Audience: oidc.Audience{t.ClientID},
+		Audience: oidc.StrOrSlice{t.ClientID},
 		ACR:      t.Authorization.ACR,
 		AMR:      t.Authorization.AMR,
 		IssuedAt: oidc.NewUnixTime(t.now()),
@@ -369,7 +369,7 @@ type TokenResponse struct {
 	// is up to the application to store _all_ the desired information in the
 	// token correctly, and to obey the OIDC spec. The handler will make no
 	// changes to this token.
-	IDToken oidc.Claims
+	IDToken oidc.IDClaims
 
 	// AccessTokenValidUntil indicates how long the returned authorization token
 	// should be valid for.
@@ -778,7 +778,7 @@ func verifyCodeChallenge(codeVerifier, storedCodeChallenge string) bool {
 	return computedChallenge == storedCodeChallenge
 }
 
-func claimsToRawJWT(claims oidc.Claims) (*jwt.RawJWT, error) {
+func claimsToRawJWT(claims oidc.IDClaims) (*jwt.RawJWT, error) {
 	var exp *time.Time
 	if claims.Expiry != 0 {
 		t := claims.Expiry.Time()

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"math"
 	"net/http/httptest"
 	"net/url"
 	"sync"
@@ -299,7 +298,8 @@ func TestIDTokenPrefill(t *testing.T) {
 				AuthTime: now,
 				Nonce:    "nonce",
 
-				now: nowFn,
+				issuer: "issuer",
+				now:    nowFn,
 			},
 			Want: oidc.IDClaims{
 				Issuer:   "issuer",
@@ -316,7 +316,7 @@ func TestIDTokenPrefill(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			tok := tc.TReq.PrefillIDToken("issuer", "subject", now)
+			tok := tc.TReq.PrefillIDToken("subject", now)
 			if diff := cmp.Diff(tc.Want, tok, cmpopts.IgnoreUnexported(oidc.IDClaims{})); diff != "" {
 				t.Error(diff)
 			}
@@ -330,6 +330,8 @@ func (u *unauthorizedErrImpl) Unauthorized() bool { return true }
 
 func TestToken(t *testing.T) {
 	const (
+		issuer = "https://issuer"
+
 		clientID     = "client-id"
 		clientSecret = "client-secret"
 		redirectURI  = "https://redirect"
@@ -341,6 +343,8 @@ func TestToken(t *testing.T) {
 
 	newOIDC := func() *OIDC {
 		return &OIDC{
+			issuer: issuer,
+
 			smgr:     newStubSMGR(),
 			handleFn: KeysetHandle,
 
@@ -392,11 +396,11 @@ func TestToken(t *testing.T) {
 		return utokstr
 	}
 
-	newHandler := func(t *testing.T) func(req *TokenRequest) (*TokenResponse, error) {
+	newHandler := func(_ *testing.T, expIn time.Duration) func(req *TokenRequest) (*TokenResponse, error) {
 		return func(req *TokenRequest) (*TokenResponse, error) {
 			return &TokenResponse{
-				IDToken:               req.PrefillIDToken("http://iss", "sub", time.Now().Add(time.Minute)),
-				AccessTokenValidUntil: time.Now().Add(1 * time.Minute),
+				IDToken:     req.PrefillIDToken("sub", time.Now().Add(expIn)),
+				AccessToken: req.PrefillAccessToken("sub", time.Now().Add(expIn)),
 			}, nil
 		}
 	}
@@ -413,7 +417,7 @@ func TestToken(t *testing.T) {
 			ClientSecret: clientSecret,
 		}
 
-		tresp, err := o.token(context.Background(), treq, newHandler(t))
+		tresp, err := o.token(context.Background(), treq, newHandler(t, time.Minute))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -435,13 +439,13 @@ func TestToken(t *testing.T) {
 			ClientSecret: clientSecret,
 		}
 
-		_, err := o.token(context.Background(), treq, newHandler(t))
+		_, err := o.token(context.Background(), treq, newHandler(t, time.Minute))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		// replay fails
-		_, err = o.token(context.Background(), treq, newHandler(t))
+		_, err = o.token(context.Background(), treq, newHandler(t, time.Minute))
 		if err, ok := err.(*oauth2.TokenError); !ok || err.ErrorCode != oauth2.TokenErrorCodeInvalidGrant {
 			t.Errorf("want invalid token grant error, got: %v", err)
 		}
@@ -459,7 +463,7 @@ func TestToken(t *testing.T) {
 			ClientSecret: "invalid-secret",
 		}
 
-		_, err := o.token(context.Background(), treq, newHandler(t))
+		_, err := o.token(context.Background(), treq, newHandler(t, time.Minute))
 		if err, ok := err.(*oauth2.TokenError); !ok || err.ErrorCode != oauth2.TokenErrorCodeUnauthorizedClient {
 			t.Errorf("want unauthorized client error, got: %v", err)
 		}
@@ -479,7 +483,7 @@ func TestToken(t *testing.T) {
 			ClientSecret: otherClientSecret,
 		}
 
-		_, err := o.token(context.Background(), treq, newHandler(t))
+		_, err := o.token(context.Background(), treq, newHandler(t, time.Minute))
 		if err, ok := err.(*oauth2.TokenError); !ok || err.ErrorCode != oauth2.TokenErrorCodeUnauthorizedClient {
 			t.Errorf("want unauthorized client error, got: %v", err)
 		}
@@ -497,10 +501,9 @@ func TestToken(t *testing.T) {
 			ClientSecret: clientSecret,
 		}
 
-		ih := newHandler(t)
+		ih := newHandler(t, 5*time.Minute)
 		h := func(req *TokenRequest) (*TokenResponse, error) {
 			r, err := ih(req)
-			r.AccessTokenValidUntil = time.Now().Add(5 * time.Minute)
 			return r, err
 		}
 
@@ -515,8 +518,8 @@ func TestToken(t *testing.T) {
 
 		// compare whole seconds, we calculate this based on a expiresAt - now
 		// delta so the function run time is factored in.
-		if math.Round(tresp.ExpiresIn.Seconds()) != math.Round((5 * time.Minute).Seconds()) {
-			t.Errorf("want token exp %f, got: %f", math.Round((5 * time.Minute).Seconds()), math.Round(tresp.ExpiresIn.Seconds()))
+		if tresp.ExpiresIn > 5*time.Minute+2*time.Second || tresp.ExpiresIn < 5*time.Minute-2*time.Second {
+			t.Errorf("want token exp within 2s of %f, got: %f", 5*time.Minute.Seconds(), tresp.ExpiresIn.Seconds())
 		}
 	})
 
@@ -524,10 +527,9 @@ func TestToken(t *testing.T) {
 		o := newOIDC()
 		codeToken := newCodeSess(t, o.smgr)
 
-		ih := newHandler(t)
+		ih := newHandler(t, time.Minute)
 		h := func(req *TokenRequest) (*TokenResponse, error) {
 			r, err := ih(req)
-			r.AccessTokenValidUntil = o.now().Add(5 * time.Minute)
 			r.RefreshTokenValidUntil = o.now().Add(10 * time.Minute)
 			r.IssueRefreshToken = true
 			return r, err
@@ -605,13 +607,12 @@ func TestToken(t *testing.T) {
 		var returnErr error
 		const errDesc = "Refresh unauthorized"
 
-		ih := newHandler(t)
+		ih := newHandler(t, time.Minute)
 		h := func(req *TokenRequest) (*TokenResponse, error) {
 			if returnErr != nil {
 				return nil, returnErr
 			}
 			r, err := ih(req)
-			r.AccessTokenValidUntil = o.now().Add(5 * time.Minute)
 			r.RefreshTokenValidUntil = o.now().Add(10 * time.Minute)
 			r.IssueRefreshToken = true
 			return r, err
@@ -797,7 +798,7 @@ func TestFetchCodeSession(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			smgr := newStubSMGR()
 
-			oidc, err := New(&Config{}, smgr, &staticclients.Clients{}, KeysetHandle)
+			oidc, err := New(&Config{Issuer: "http://issuer"}, smgr, &staticclients.Clients{}, KeysetHandle)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -870,7 +871,7 @@ func TestFetchRefreshSession(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			smgr := newStubSMGR()
 
-			oidc, err := New(&Config{}, smgr, &staticclients.Clients{}, KeysetHandle)
+			oidc, err := New(&Config{Issuer: "http://issuer"}, smgr, &staticclients.Clients{}, KeysetHandle)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -900,7 +901,7 @@ func TestFetchRefreshSession(t *testing.T) {
 func TestUserinfo(t *testing.T) {
 	echoHandler := func(w io.Writer, uireq *UserinfoRequest) error {
 		o := map[string]interface{}{
-			"gotsess": uireq.SessionID,
+			"gotsub": uireq.Subject,
 		}
 
 		if err := json.NewEncoder(w).Encode(o); err != nil {
@@ -910,11 +911,32 @@ func TestUserinfo(t *testing.T) {
 		return nil
 	}
 
+	signAccessToken := func(cl oidc.AccessTokenClaims) string {
+		signer, err := jwt.NewSigner(KeysetHandle())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rawATJWT, err := accessTokenClaimsToRawJWT(cl)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		sat, err := signer.SignAndEncode(rawATJWT)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return sat
+	}
+
+	issuer := "http://iss"
+
 	for _, tc := range []struct {
 		Name string
 		// Setup should return both a session to be persisted, and an access
 		// token
-		Setup   func(t *testing.T) (sess *sessionV2, accessToken string)
+		Setup   func(t *testing.T) (accessToken string)
 		Handler func(w io.Writer, uireq *UserinfoRequest) error
 		// WantErr signifies that we expect an error
 		WantErr bool
@@ -923,64 +945,46 @@ func TestUserinfo(t *testing.T) {
 	}{
 		{
 			Name: "Simple output, valid session",
-			Setup: func(t *testing.T) (sess *sessionV2, accessToken string) {
-				sid := "session-id"
-				u, s, err := newToken(sid, time.Now().Add(1*time.Minute))
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				sess = &sessionV2{
-					ID:          sid,
-					AccessToken: s,
-					Expiry:      time.Now().Add(1 * time.Minute),
-				}
-
-				return sess, mustMarshal(u)
+			Setup: func(t *testing.T) (accessToken string) {
+				return signAccessToken(oidc.AccessTokenClaims{
+					Issuer:  issuer,
+					Subject: "sub",
+					Expiry:  oidc.NewUnixTime(time.Now().Add(1 * time.Minute)),
+				})
 			},
 			Handler: echoHandler,
 			WantJSON: map[string]interface{}{
-				"gotsess": "session-id",
+				"gotsub": "sub",
 			},
 		},
 		{
-			Name: "Token for non-existent session",
-			Setup: func(t *testing.T) (sess *sessionV2, accessToken string) {
-				sid := "session-id"
-				u, _, err := newToken(sid, time.Now().Add(1*time.Minute))
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				return nil, mustMarshal(u)
+			Name: "Token for other issuer",
+			Setup: func(t *testing.T) (accessToken string) {
+				return signAccessToken(oidc.AccessTokenClaims{
+					Issuer:  "http://other",
+					Subject: "sub",
+					Expiry:  oidc.NewUnixTime(time.Now().Add(1 * time.Minute)),
+				})
 			},
 			Handler: echoHandler,
 			WantErr: true,
 		},
 		{
 			Name: "Expired access token",
-			Setup: func(t *testing.T) (sess *sessionV2, accessToken string) {
-				sid := "session-id"
-				u, s, err := newToken(sid, time.Now().Add(-1*time.Minute))
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				sess = &sessionV2{
-					ID:          sid,
-					AccessToken: s,
-					Expiry:      time.Now().Add(1 * time.Minute),
-				}
-
-				return sess, mustMarshal(u)
+			Setup: func(t *testing.T) (accessToken string) {
+				return signAccessToken(oidc.AccessTokenClaims{
+					Issuer:  issuer,
+					Subject: "sub",
+					Expiry:  oidc.NewUnixTime(time.Now().Add(-1 * time.Minute)),
+				})
 			},
 			Handler: echoHandler,
 			WantErr: true,
 		},
 		{
 			Name: "No access token",
-			Setup: func(t *testing.T) (sess *sessionV2, accessToken string) {
-				return nil, ""
+			Setup: func(t *testing.T) (accessToken string) {
+				return ""
 			},
 			Handler: echoHandler,
 			WantErr: true,
@@ -989,18 +993,12 @@ func TestUserinfo(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			smgr := newStubSMGR()
 
-			oidc, err := New(&Config{}, smgr, &staticclients.Clients{}, KeysetHandle)
+			oidc, err := New(&Config{Issuer: issuer}, smgr, &staticclients.Clients{}, KeysetHandle)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			sess, at := tc.Setup(t)
-
-			if sess != nil {
-				if err := putSession(context.Background(), smgr, sess); err != nil {
-					t.Fatalf("error persisting initial session: %v", err)
-				}
-			}
+			at := tc.Setup(t)
 
 			rec := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/userinfo", nil)

--- a/core/oidc_test.go
+++ b/core/oidc_test.go
@@ -284,7 +284,7 @@ func TestIDTokenPrefill(t *testing.T) {
 	for _, tc := range []struct {
 		Name string
 		TReq TokenRequest
-		Want oidc.Claims
+		Want oidc.IDClaims
 	}{
 		{
 			Name: "Fields filled",
@@ -301,10 +301,10 @@ func TestIDTokenPrefill(t *testing.T) {
 
 				now: nowFn,
 			},
-			Want: oidc.Claims{
+			Want: oidc.IDClaims{
 				Issuer:   "issuer",
 				Subject:  "subject",
-				Audience: oidc.Audience{"client"},
+				Audience: oidc.StrOrSlice{"client"},
 				Expiry:   1574686451,
 				IssuedAt: 1574686451,
 				AuthTime: 1574686451,
@@ -317,7 +317,7 @@ func TestIDTokenPrefill(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			tok := tc.TReq.PrefillIDToken("issuer", "subject", now)
-			if diff := cmp.Diff(tc.Want, tok, cmpopts.IgnoreUnexported(oidc.Claims{})); diff != "" {
+			if diff := cmp.Diff(tc.Want, tok, cmpopts.IgnoreUnexported(oidc.IDClaims{})); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/core/sessionmgr.go
+++ b/core/sessionmgr.go
@@ -89,10 +89,7 @@ type sessionV2 struct {
 	//
 	// https://tools.ietf.org/html/rfc6819#section-4.4.1.1
 	AuthCodeRedeemed bool `json:"auth_code_redeemed,omitempty"`
-	// The current access token, if one has been issued. It's expiration time
-	// should always be checked.
-	AccessToken *accessToken `json:"access_token,omitempty"`
-	// The currently valid refresh token for this session. I
+	// The currently valid refresh token for this session.
 	RefreshToken *accessToken `json:"refresh_token,omitempty"`
 	// The time the whole session should be expired at. It should be garbage
 	// collected at this time.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -75,6 +75,7 @@ func TestE2E(t *testing.T) {
 			defer cliSvr.Close()
 
 			cfg := &core.Config{
+				Issuer:           "http://issuer",
 				AuthValidityTime: 1 * time.Minute,
 				CodeValidityTime: 1 * time.Minute,
 			}
@@ -114,8 +115,8 @@ func TestE2E(t *testing.T) {
 			mux.HandleFunc("/token", func(w http.ResponseWriter, req *http.Request) {
 				err := oidcHandlers.Token(w, req, func(tr *core.TokenRequest) (*core.TokenResponse, error) {
 					return &core.TokenResponse{
-						IDToken:                tr.PrefillIDToken(oidcSvr.URL, "test-sub", time.Now().Add(1*time.Minute)),
-						AccessTokenValidUntil:  time.Now().Add(1 * time.Minute),
+						IDToken:                tr.PrefillIDToken("test-sub", time.Now().Add(1*time.Minute)),
+						AccessToken:            tr.PrefillAccessToken("test-sub", time.Now().Add(1*time.Minute)),
 						IssueRefreshToken:      true,
 						RefreshTokenValidUntil: time.Now().Add(2 * time.Minute),
 					}, nil

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.6.0
 	github.com/tink-crypto/tink-go/v2 v2.1.0
 	golang.org/x/crypto v0.20.0
 	golang.org/x/net v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/tink-crypto/tink-go/v2 v2.1.0 h1:QXFBguwMwTIaU17EgZpEJWsUSc60b1BAGTzBIoMdmok=
 github.com/tink-crypto/tink-go/v2 v2.1.0/go.mod h1:y1TnYFt1i2eZVfx4OGc+C+EMp4CoKWAw2VSEuoicHHI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -159,7 +159,7 @@ func (h *Handler) Wrap(next http.Handler) http.Handler {
 //
 // This function may modify the session if a token is refreshed, so it must be
 // saved afterward.
-func (h *Handler) authenticateExisting(r *http.Request, session *SessionData) (*oauth2.Token, *oidc.Claims, error) {
+func (h *Handler) authenticateExisting(r *http.Request, session *SessionData) (*oauth2.Token, *oidc.IDClaims, error) {
 	ctx := r.Context()
 
 	if session.Token == nil {
@@ -317,11 +317,11 @@ func (h *Handler) verificationOptions() oidc.VerificationOpts {
 
 type contextData struct {
 	token  *oauth2.Token
-	claims *oidc.Claims
+	claims *oidc.IDClaims
 }
 
 // ClaimsFromContext returns the claims for the given request context
-func ClaimsFromContext(ctx context.Context) *oidc.Claims {
+func ClaimsFromContext(ctx context.Context) *oidc.IDClaims {
 	cd, ok := ctx.Value(tokenContextKey{}).(contextData)
 	if !ok {
 		return nil

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -291,7 +291,7 @@ func TestMiddleware_HappyPath(t *testing.T) {
 func TestContext(t *testing.T) {
 	var ( // Capture in handler
 		gotTokSrc oauth2.TokenSource
-		gotClaims *oidc.Claims
+		gotClaims *oidc.IDClaims
 		gotRaw    string
 	)
 	protected := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/provider.go
+++ b/provider.go
@@ -181,8 +181,12 @@ type VerificationOpts struct {
 	ACRValues []string
 }
 
-func (p *Provider) VerifyAccessToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*IDClaims, error) {
-	return p.verifyToken(ctx, tok.AccessToken, opts)
+func (p *Provider) VerifyAccessToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*AccessTokenClaims, error) {
+	var acl AccessTokenClaims
+	if err := p.verifyToken(ctx, tok.AccessToken, opts, &acl); err != nil {
+		return nil, err
+	}
+	return &acl, nil
 }
 
 func (p *Provider) VerifyIDToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*IDClaims, error) {
@@ -190,10 +194,14 @@ func (p *Provider) VerifyIDToken(ctx context.Context, tok *oauth2.Token, opts Ve
 	if !ok {
 		return nil, fmt.Errorf("token does not contain an ID token")
 	}
-	return p.verifyToken(ctx, idt, opts)
+	var idcl IDClaims
+	if err := p.verifyToken(ctx, idt, opts, &idcl); err != nil {
+		return nil, err
+	}
+	return &idcl, nil
 }
 
-func (p *Provider) verifyToken(ctx context.Context, rawJWT string, opts VerificationOpts) (*IDClaims, error) {
+func (p *Provider) verifyToken(ctx context.Context, rawJWT string, opts VerificationOpts, into validatable) error {
 	vops := &jwt.ValidatorOpts{
 		ExpectedIssuer:  &p.Metadata.Issuer,
 		IgnoreAudiences: opts.IgnoreClientID,
@@ -204,19 +212,23 @@ func (p *Provider) verifyToken(ctx context.Context, rawJWT string, opts Verifica
 
 	vjwt, err := p.VerifyToken(ctx, rawJWT, vops)
 	if err != nil {
-		return nil, fmt.Errorf("jwt verification failed: %w", err)
+		return fmt.Errorf("jwt verification failed: %w", err)
 	}
 
-	cl, err := claimsFromVerifiedJWT(vjwt)
+	// TODO(lstoll) is this good enough? Do we want to do more/other processing?
+	b, err := vjwt.JSONPayload()
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("extracting JSON payload: %w", err)
+	}
+	if err := json.Unmarshal(b, &into); err != nil {
+		return fmt.Errorf("unmarshaling claims: %w", err)
 	}
 
-	if len(opts.ACRValues) > 0 && !slices.Contains(opts.ACRValues, cl.ACR) {
-		return nil, fmt.Errorf("token does not meet ACR requirements")
+	if len(opts.ACRValues) > 0 && !slices.Contains(opts.ACRValues, into.acr()) {
+		return fmt.Errorf("token does not meet ACR requirements")
 	}
 
-	return cl, nil
+	return nil
 }
 
 func (p *Provider) Userinfo(ctx context.Context, tokenSource oauth2.TokenSource) (*IDClaims, error) {
@@ -269,4 +281,16 @@ func (s *staticPublicHandle) PublicHandle(context.Context) (*keyset.Handle, erro
 
 func NewStaticPublicHandle(h *keyset.Handle) PublicHandle {
 	return &staticPublicHandle{h: h}
+}
+
+type validatable interface {
+	acr() string
+}
+
+func (c *IDClaims) acr() string {
+	return c.ACR
+}
+
+func (a *AccessTokenClaims) acr() string {
+	return a.ACR
 }

--- a/provider.go
+++ b/provider.go
@@ -181,11 +181,11 @@ type VerificationOpts struct {
 	ACRValues []string
 }
 
-func (p *Provider) VerifyAccessToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*Claims, error) {
+func (p *Provider) VerifyAccessToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*IDClaims, error) {
 	return p.verifyToken(ctx, tok.AccessToken, opts)
 }
 
-func (p *Provider) VerifyIDToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*Claims, error) {
+func (p *Provider) VerifyIDToken(ctx context.Context, tok *oauth2.Token, opts VerificationOpts) (*IDClaims, error) {
 	idt, ok := IDToken(tok)
 	if !ok {
 		return nil, fmt.Errorf("token does not contain an ID token")
@@ -193,7 +193,7 @@ func (p *Provider) VerifyIDToken(ctx context.Context, tok *oauth2.Token, opts Ve
 	return p.verifyToken(ctx, idt, opts)
 }
 
-func (p *Provider) verifyToken(ctx context.Context, rawJWT string, opts VerificationOpts) (*Claims, error) {
+func (p *Provider) verifyToken(ctx context.Context, rawJWT string, opts VerificationOpts) (*IDClaims, error) {
 	vops := &jwt.ValidatorOpts{
 		ExpectedIssuer:  &p.Metadata.Issuer,
 		IgnoreAudiences: opts.IgnoreClientID,
@@ -219,7 +219,7 @@ func (p *Provider) verifyToken(ctx context.Context, rawJWT string, opts Verifica
 	return cl, nil
 }
 
-func (p *Provider) Userinfo(ctx context.Context, tokenSource oauth2.TokenSource) (*Claims, error) {
+func (p *Provider) Userinfo(ctx context.Context, tokenSource oauth2.TokenSource) (*IDClaims, error) {
 	if p.Metadata.UserinfoEndpoint == "" {
 		return nil, fmt.Errorf("provider does not have a userinfo endpoint")
 	}
@@ -244,7 +244,7 @@ func (p *Provider) Userinfo(ctx context.Context, tokenSource oauth2.TokenSource)
 		return nil, fmt.Errorf("bad response from server: http %d", resp.StatusCode)
 	}
 
-	var cl Claims
+	var cl IDClaims
 
 	if err := json.NewDecoder(resp.Body).Decode(&cl); err != nil {
 		return nil, fmt.Errorf("failed decoding response body: %v", err)


### PR DESCRIPTION
There's a format for this now: https://datatracker.ietf.org/doc/html/rfc9068

This will let us get out of the business of using ID tokens for access, which we shouldn't be doing. This makes the access token a usable, independently verifiable items that is compatible with the uses of identity tokens we have. If more user info is required, that's what the user info endpoint is for.

CLIs starting to move towards using this by default. A new set of claims are introduced to differentiate these from the ID token claims.