### PR TITLE
Make core Keyset handle consistent

### DIFF
--- a/cmd/oidc-example-op/main.go
+++ b/cmd/oidc-example-op/main.go
@@ -30,7 +30,7 @@ func main() {
 		Issuer:           iss,
 		AuthValidityTime: 5 * time.Minute,
 		CodeValidityTime: 5 * time.Minute,
-	}, smgr, clients, core.StaticKeysetHandle(privh))
+	}, smgr, clients, core.NewStaticKeysetHandle(privh))
 	if err != nil {
 		log.Fatalf("Failed to create OIDC server instance: %v", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -91,7 +91,7 @@ func TestE2E(t *testing.T) {
 				},
 			}
 
-			oidcHandlers, err := core.New(cfg, smgr, clientSource, KeysetHandle)
+			oidcHandlers, err := core.New(cfg, smgr, clientSource, testKeysetHandle())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -138,7 +138,7 @@ func TestE2E(t *testing.T) {
 				}
 			})
 
-			privh := KeysetHandle()
+			privh, err := testKeysetHandle().Handle(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -332,7 +332,7 @@ var (
 	thMu sync.Mutex
 )
 
-func KeysetHandle() *keyset.Handle {
+func testKeysetHandle() core.KeysetHandle {
 	thMu.Lock()
 	defer thMu.Unlock()
 	// we only make one, because it's slow
@@ -344,5 +344,5 @@ func KeysetHandle() *keyset.Handle {
 		th = h
 	}
 
-	return th
+	return core.NewStaticKeysetHandle(th)
 }


### PR DESCRIPTION
Model after oidc. Allow it to return errors, so it can be fetched dynamically.