### PR TITLE
Finish off provider interface

### DIFF
--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -270,23 +270,33 @@ func info(ctx context.Context, provider *oidc.Provider, ts oauth2.TokenSource, _
 	fmt.Printf("Access Token: %s\n", tok.AccessToken)
 	fmt.Printf("Access Token expires: %s\n", tok.Expiry.String())
 	if isJWT(tok.AccessToken) {
-		claims, err := provider.VerifyAccessToken(ctx, tok, oidc.VerificationOpts{IgnoreClientID: true})
+		jwt, claims, err := provider.VerifyAccessToken(ctx, tok, oidc.AccessTokenValidationOpts{IgnoreAudience: true})
 		if err != nil {
 			return fmt.Errorf("access token verification: %w", err)
 		}
 		fmt.Printf("Access token claims expires: %s\n", claims.Expiry.Time().String())
 		fmt.Printf("Access token claims: %v\n", claims)
+		jb, err := jwt.JSONPayload()
+		if err != nil {
+			return fmt.Errorf("getting json payload: %w", err)
+		}
+		fmt.Printf("Access token full claims: %v\n", string(jb))
 	}
 	fmt.Printf("Refresh Token: %s\n", tok.RefreshToken)
 	idt, ok := oidc.IDToken(tok)
 	if ok {
-		claims, err := provider.VerifyIDToken(ctx, tok, oidc.VerificationOpts{IgnoreClientID: true})
+		jwt, claims, err := provider.VerifyIDToken(ctx, tok, oidc.IDTokenValidationOpts{IgnoreAudience: true})
 		if err != nil {
 			return fmt.Errorf("ID token verification: %w", err)
 		}
 		fmt.Printf("ID token: %s\n", idt)
 		fmt.Printf("ID token claims expires: %s\n", claims.Expiry.Time().String())
-		fmt.Printf("ID token claims: %v\n", claims)
+		fmt.Printf("ID token standard claims: %v\n", claims)
+		jb, err := jwt.JSONPayload()
+		if err != nil {
+			return fmt.Errorf("getting json payload: %w", err)
+		}
+		fmt.Printf("ID token full claims: %v\n", string(jb))
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	golang.org/x/net v0.30.0
 	golang.org/x/oauth2 v0.23.0
 	golang.org/x/term v0.25.0
-	google.golang.org/protobuf v1.35.1
 )
 
-require golang.org/x/sys v0.26.0 // indirect
+require (
+	golang.org/x/sys v0.26.0 // indirect
+	google.golang.org/protobuf v1.35.1 // indirect
+)

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -216,7 +216,7 @@ func (s *mockOIDCServer) handleKeys(w http.ResponseWriter, r *http.Request) {
 
 func TestMiddleware_HappyPath(t *testing.T) {
 	protected := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(fmt.Sprintf("sub: %s", ClaimsFromContext(r.Context()).Subject)))
+		_, _ = w.Write([]byte(fmt.Sprintf("sub: %s", IDClaimsFromContext(r.Context()).Subject)))
 	})
 
 	oidcServer, oidcHTTPServer := startMockOIDCServer(t)
@@ -294,14 +294,16 @@ func TestMiddleware_HappyPath(t *testing.T) {
 
 func TestContext(t *testing.T) {
 	var ( // Capture in handler
-		gotTokSrc oauth2.TokenSource
+		// gotTokSrc oauth2.TokenSource
 		gotClaims *oidc.IDClaims
-		gotRaw    string
+		gotJWT    *jwt.VerifiedJWT
+		// gotRaw    string
 	)
 	protected := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotTokSrc = TokenSourceFromContext(r.Context())
-		gotClaims = ClaimsFromContext(r.Context())
-		gotRaw = RawIDTokenFromContext(r.Context())
+		// gotTokSrc = TokenSourceFromContext(r.Context())
+		gotClaims = IDClaimsFromContext(r.Context())
+		gotJWT = IDJWTFromContext(r.Context())
+		// gotRaw = RawIDTokenFromContext(r.Context())
 	})
 
 	oidcServer, oidcHTTPServer := startMockOIDCServer(t)
@@ -344,14 +346,23 @@ func TestContext(t *testing.T) {
 	if gotClaims.Subject != "valid-subject" {
 		t.Errorf("want claims sub valid-subject, got: %s", gotClaims.Subject)
 	}
-	if gotRaw == "" {
-		t.Error("context missing id_token")
+
+	jwtsub, err := gotJWT.Subject()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jwtsub != "valid-subject" {
+		t.Errorf("want jwt sub valid-subject, got: %s", gotClaims.Subject)
 	}
 
-	_, err = gotTokSrc.Token()
-	if err != nil {
-		t.Fatalf("calling token source token: %v", err)
-	}
+	// if gotRaw == "" {
+	// 	t.Error("context missing id_token")
+	// }
+
+	// _, err = gotTokSrc.Token()
+	// if err != nil {
+	// 	t.Fatalf("calling token source token: %v", err)
+	// }
 }
 
 func checkResponse(t *testing.T, resp *http.Response) (body []byte) {

--- a/provider.go
+++ b/provider.go
@@ -144,7 +144,7 @@ func (p *Provider) PublicHandle(ctx context.Context) (*keyset.Handle, error) {
 // implement revocation.
 func (p *Provider) FetchKeys(ctx context.Context) error {
 	if p.OverrideHandle != nil {
-		return fmt.Errorf("cannot fetch keys when handle is overriden")
+		return fmt.Errorf("cannot fetch keys when handle is overridden")
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.Metadata.JWKSURI, nil)

--- a/provider_test.go
+++ b/provider_test.go
@@ -245,6 +245,23 @@ func TestAccessTokenVerification(t *testing.T) {
 	}
 }
 
+func TestRefetch(t *testing.T) {
+	svr, _ := newMockDiscoveryServer(t)
+
+	provider, err := DiscoverProvider(context.TODO(), svr.URL, &DiscoverOptions{
+		HTTPClient: svr.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	provider.lastHandle = nil
+
+	if _, err := provider.PublicHandle(context.TODO()); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAccessTokenHeaderRequiredVerification(t *testing.T) {
 	svr, h := newMockDiscoveryServer(t)
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,5 +1,22 @@
 package oidc
 
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tink-crypto/tink-go/v2/jwt"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	"golang.org/x/oauth2"
+)
+
 /*
 
 
@@ -39,3 +56,291 @@ func TestDiscovery(t *testing.T) {
 
 
 */
+
+func TestProviderDiscovery(t *testing.T) {
+	svr, _ := newMockDiscoveryServer(t)
+
+	if _, err := DiscoverProvider(context.TODO(), svr.URL, &DiscoverOptions{
+		HTTPClient: svr.Client(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTokenVerification(t *testing.T) {
+	svr, h := newMockDiscoveryServer(t)
+
+	provider, err := DiscoverProvider(context.TODO(), svr.URL, &DiscoverOptions{
+		HTTPClient: svr.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		Name       string
+		Token      *jwt.RawJWTOptions
+		VerifOpts  *jwt.ValidatorOpts
+		WantErrStr string
+	}{
+		{
+			Name: "Simple valid token",
+			Token: &jwt.RawJWTOptions{
+				Issuer:    ptr(svr.URL),
+				ExpiresAt: ptr(time.Now().Add(1 * time.Minute)),
+			},
+		},
+		{
+			Name: "Issuer mismatch",
+			Token: &jwt.RawJWTOptions{
+				Issuer:    ptr("https://other"),
+				ExpiresAt: ptr(time.Now().Add(1 * time.Minute)),
+			},
+			WantErrStr: "validating issuer claim",
+		},
+		{
+			Name: "Expired",
+			Token: &jwt.RawJWTOptions{
+				Issuer:    ptr(svr.URL),
+				ExpiresAt: ptr(time.Now().Add(-1 * time.Minute)),
+			},
+			WantErrStr: "token has expired",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			signed := signJWTOpts(t, h, tc.Token)
+
+			_, err := provider.VerifyToken(context.TODO(), signed, tc.VerifOpts)
+			if (err != nil && tc.WantErrStr == "") || (err == nil && tc.WantErrStr != "") || (err != nil && !strings.Contains(err.Error(), tc.WantErrStr)) {
+				t.Fatalf("want err containing %s, got: %v", tc.WantErrStr, err)
+			}
+		})
+	}
+}
+
+func TestIDTokenVerification(t *testing.T) {
+	svr, h := newMockDiscoveryServer(t)
+
+	provider, err := DiscoverProvider(context.TODO(), svr.URL, &DiscoverOptions{
+		HTTPClient: svr.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		Name       string
+		Token      *IDClaims
+		VerifOpts  IDTokenValidationOpts
+		WantErrStr string
+	}{
+		{
+			Name: "Simple valid token",
+			Token: &IDClaims{
+				Issuer:   svr.URL,
+				Expiry:   UnixTime(time.Now().Add(1 * time.Minute).Unix()),
+				Audience: StrOrSlice([]string{"hello"}),
+			},
+			VerifOpts: IDTokenValidationOpts{
+				Audience: "hello",
+			},
+		},
+		{
+			Name: "Audience mismatch",
+			Token: &IDClaims{
+				Issuer:   svr.URL,
+				Expiry:   UnixTime(time.Now().Add(1 * time.Minute).Unix()),
+				Audience: StrOrSlice([]string{"hello"}),
+			},
+			VerifOpts: IDTokenValidationOpts{
+				Audience: "other",
+			},
+			WantErrStr: "validating audience claim",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			jwt, err := tc.Token.ToJWT(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			signed := signRawJWT(t, h, jwt)
+
+			o2t := TokenWithID(&oauth2.Token{}, signed)
+
+			_, gotc, err := provider.VerifyIDToken(context.TODO(), o2t, tc.VerifOpts)
+			if (err != nil && tc.WantErrStr == "") || (err == nil && tc.WantErrStr != "") || (err != nil && !strings.Contains(err.Error(), tc.WantErrStr)) {
+				t.Fatalf("want err containing %s, got: %v", tc.WantErrStr, err)
+			}
+
+			if err == nil {
+				if diff := cmp.Diff(tc.Token, gotc, cmpopts.IgnoreUnexported(IDClaims{})); diff != "" {
+					t.Error(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestAccessTokenVerification(t *testing.T) {
+	svr, h := newMockDiscoveryServer(t)
+
+	provider, err := DiscoverProvider(context.TODO(), svr.URL, &DiscoverOptions{
+		HTTPClient: svr.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		Name       string
+		Token      *AccessTokenClaims
+		VerifOpts  AccessTokenValidationOpts
+		WantErrStr string
+	}{
+		{
+			Name: "Simple valid token",
+			Token: &AccessTokenClaims{
+				Issuer:   svr.URL,
+				Expiry:   UnixTime(time.Now().Add(1 * time.Minute).Unix()),
+				Audience: StrOrSlice([]string{"hello"}),
+			},
+			VerifOpts: AccessTokenValidationOpts{
+				Audience: "hello",
+			},
+		},
+		{
+			Name: "Audience mismatch",
+			Token: &AccessTokenClaims{
+				Issuer:   svr.URL,
+				Expiry:   UnixTime(time.Now().Add(1 * time.Minute).Unix()),
+				Audience: StrOrSlice([]string{"hello"}),
+			},
+			VerifOpts: AccessTokenValidationOpts{
+				Audience: "other",
+			},
+			WantErrStr: "validating audience claim",
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			jwt, err := tc.Token.ToJWT(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			o2t := &oauth2.Token{
+				AccessToken: signRawJWT(t, h, jwt),
+			}
+
+			_, gotc, err := provider.VerifyAccessToken(context.TODO(), o2t, tc.VerifOpts)
+			if (err != nil && tc.WantErrStr == "") || (err == nil && tc.WantErrStr != "") || (err != nil && !strings.Contains(err.Error(), tc.WantErrStr)) {
+				t.Fatalf("want err containing %s, got: %v", tc.WantErrStr, err)
+			}
+
+			if err == nil {
+				if diff := cmp.Diff(tc.Token, gotc, cmpopts.IgnoreUnexported(IDClaims{})); diff != "" {
+					t.Error(diff)
+				}
+			}
+		})
+	}
+}
+
+func TestAccessTokenHeaderRequiredVerification(t *testing.T) {
+	svr, h := newMockDiscoveryServer(t)
+
+	provider, err := DiscoverProvider(context.TODO(), svr.URL, &DiscoverOptions{
+		HTTPClient: svr.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idclaims := &IDClaims{
+		Issuer:   svr.URL,
+		Expiry:   UnixTime(time.Now().Add(1 * time.Minute).Unix()),
+		Audience: StrOrSlice([]string{"hello"}),
+	}
+	jwt, err := idclaims.ToJWT(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o2t := &oauth2.Token{
+		AccessToken: signRawJWT(t, h, jwt),
+	}
+
+	_, _, err = provider.VerifyAccessToken(context.TODO(), o2t, AccessTokenValidationOpts{IgnoreAudience: true})
+	if err == nil {
+		t.Fatal("verifying an id token as an access token should have failed due to header mismatch")
+	}
+}
+
+func newMockDiscoveryServer(t *testing.T) (*httptest.Server, *keyset.Handle) {
+	h, err := keyset.NewHandle(jwt.ES256Template())
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("ks: %#v", err)
+	ph, err := h.Public()
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwks, err := jwt.JWKSetFromPublicKeysetHandle(ph)
+	if err != nil {
+		t.Fatalf("creating jwks from handle: %v", err)
+	}
+
+	svr := httptest.NewTLSServer(nil)
+
+	mux := http.NewServeMux()
+
+	pmd := &ProviderMetadata{
+		Issuer:                           svr.URL,
+		IDTokenSigningAlgValuesSupported: []string{"ES256"},
+		JWKSURI:                          svr.URL + "/.well-known/jwks.json",
+	}
+
+	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if err := json.NewEncoder(w).Encode(pmd); err != nil {
+			http.Error(w, "Internal Error", http.StatusInternalServerError)
+			return
+		}
+	})
+	mux.HandleFunc("GET /.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwk-set+json")
+
+		if _, err := w.Write(jwks); err != nil {
+			http.Error(w, "Internal Error", http.StatusInternalServerError)
+			return
+		}
+	})
+
+	svr.Config.Handler = mux
+
+	return svr, h
+}
+
+func signJWTOpts(t *testing.T, h *keyset.Handle, jwtOpts *jwt.RawJWTOptions) string {
+	rawJWT, err := jwt.NewRawJWT(jwtOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return signRawJWT(t, h, rawJWT)
+}
+
+func signRawJWT(t *testing.T, h *keyset.Handle, raw *jwt.RawJWT) string {
+	signer, err := jwt.NewSigner(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := signer.SignAndEncode(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return token
+}


### PR DESCRIPTION
This takes the current WIP provider interface, and finishes it off. Notable:

* We lean on tink for JWT operations. Rather than just getting JSON, we use its accessors. These are safer, and more consistent about the output. E.g no longer have to remember if groups are `[]string` or `[]any`, and have type asserts break etc.
* We no longer stuff extra on the claims. Instead, Claims represent only the standard claims. Other items can be fetched off the returned verified JWT.
* There is some testing finally
* ID token and Access token have distinct verification items
* We no longer always fetch the keyset if it hits the timeout, now only if a key has likely expired