### PR TITLE
Update local token source to be closer to x/oauth2 style

### DIFF
--- a/clitoken/local_token_source_test.go
+++ b/clitoken/local_token_source_test.go
@@ -1,0 +1,112 @@
+package clitoken
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+type captureOpener struct {
+	t    *testing.T
+	urlC chan string
+}
+
+func (c *captureOpener) Open(ctx context.Context, url string) error {
+	c.t.Logf("open called for: %s", url)
+	c.urlC <- url
+	return nil
+}
+
+func TestLocalTokenSource(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.TODO())
+	t.Cleanup(cancel)
+
+	const accessToken = "youareok"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /auth", func(w http.ResponseWriter, r *http.Request) {
+		redir := r.URL.Query().Get("redirect_uri")
+		redir = redir + "?code=1234&state=" + r.URL.Query().Get("state")
+		t.Logf("/auth redirect to: %s", redir)
+		http.Redirect(w, r, redir, http.StatusSeeOther)
+	})
+	mux.HandleFunc("POST /token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json;charset=UTF-8")
+		resp := map[string]any{
+			"access_token": accessToken,
+			"expires_in":   60,
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	// needs this to trust the self-signed cert. Also a demo of how to use a
+	// custom HTTP client.
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, srv.Client())
+
+	openC := make(chan string)
+	co := &captureOpener{t: t, urlC: openC}
+
+	cfg := Config{
+		OAuth2Config: oauth2.Config{
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  srv.URL + "/auth",
+				TokenURL: srv.URL + "/token",
+			},
+		},
+		Opener: co,
+	}
+
+	ts, err := cfg.TokenSource(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		tokC    = make(chan *oauth2.Token)
+		tokErrC = make(chan error)
+	)
+	go func() {
+		t, err := ts.Token()
+		if err != nil {
+			tokErrC <- err
+			return
+		}
+		tokC <- t
+	}()
+
+	select {
+	case acurl := <-openC:
+		req, err := http.NewRequest(http.MethodGet, acurl, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := srv.Client().Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("resp status: %d", resp.StatusCode)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for open")
+	}
+
+	select {
+	case err := <-tokErrC:
+		t.Fatal(err)
+	case tok := <-tokC:
+		if tok.AccessToken != accessToken {
+			t.Errorf("want access token %s, got: %#v", accessToken, tok)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for token")
+	}
+}

--- a/cmd/oidc-example-rp/server.go
+++ b/cmd/oidc-example-rp/server.go
@@ -130,7 +130,7 @@ func (s *server) callback(w http.ResponseWriter, req *http.Request) {
 		"access_token": token.AccessToken,
 	}
 
-	idt, hasIDToken := oidc.IDToken(token)
+	idt, hasIDToken := oidc.GetIDToken(token)
 	if hasIDToken {
 		jwt, _, err := s.provider.VerifyIDToken(req.Context(), token, oidc.IDTokenValidationOpts{
 			Audience: string(s.oa2Cfg.ClientID),

--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -209,7 +209,7 @@ func raw(ts oauth2.TokenSource, opts rawOpts) error {
 	}
 	var raw string = tok.AccessToken
 	if opts.UseIDToken {
-		idt, ok := oidc.IDToken(tok)
+		idt, ok := oidc.GetIDToken(tok)
 		if !ok {
 			return fmt.Errorf("response has no id_token")
 		}
@@ -244,7 +244,7 @@ func kubernetes(ts oauth2.TokenSource, opts kubeOpts) error {
 	}
 	var raw = tok.AccessToken
 	if opts.UseIDToken {
-		idt, ok := oidc.IDToken(tok)
+		idt, ok := oidc.GetIDToken(tok)
 		if !ok {
 			return fmt.Errorf("response has no id_token")
 		}
@@ -283,7 +283,7 @@ func info(ctx context.Context, provider *oidc.Provider, ts oauth2.TokenSource, _
 		fmt.Printf("Access token full claims: %v\n", string(jb))
 	}
 	fmt.Printf("Refresh Token: %s\n", tok.RefreshToken)
-	idt, ok := oidc.IDToken(tok)
+	idt, ok := oidc.GetIDToken(tok)
 	if ok {
 		jwt, claims, err := provider.VerifyIDToken(ctx, tok, oidc.IDTokenValidationOpts{IgnoreAudience: true})
 		if err != nil {

--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -158,9 +158,14 @@ func main() {
 		Endpoint:     provider.Endpoint(),
 		Scopes:       scopes,
 	}
+	clitokCfg := clitoken.Config{
+		OAuth2Config: oa2Cfg,
+		PortLow:      uint16(baseFlags.PortLow),
+		PortHigh:     uint16(baseFlags.PortHigh),
+	}
 
 	var ts oauth2.TokenSource
-	ts, err = clitoken.NewSource(ctx, oa2Cfg, clitoken.WithPortRange(baseFlags.PortLow, baseFlags.PortHigh))
+	ts, err = clitokCfg.TokenSource(ctx)
 	if err != nil {
 		fmt.Printf("getting cli token source: %v", err)
 		os.Exit(1)

--- a/id_token_source.go
+++ b/id_token_source.go
@@ -14,7 +14,7 @@ type idTokenSource struct {
 // token for outgoing requests. This is a backwards compatibility option for
 // services that expect the ID token contents, or where the access token is not
 // a JWT/not otherwise verifiable. It should be the _last_ token source in any
-// chain, the result from the should not be cached.
+// chain, the result from this should not be cached.
 //
 // Deprecated: Services should expect oauth2 access tokens, and use the userinfo
 // endpoint if profile information is required.

--- a/middleware/cookie_state.go
+++ b/middleware/cookie_state.go
@@ -55,8 +55,8 @@ func (c *Cookiestore) GetOIDCSession(r *http.Request) (*SessionData, error) {
 	} else if err == nil {
 		// got a cookie, load it
 		o2t := new(oauth2.Token)
-		o2t = oidc.TokenWithID(o2t, idtc.Value)
-		sd.Token = &oidc.MarshaledToken{
+		o2t = oidc.AddIDToken(o2t, idtc.Value)
+		sd.Token = &oidc.TokenWithID{
 			Token: o2t,
 		}
 	}

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -37,7 +37,7 @@ type SessionData struct {
 	// Logins tracks state for in-progress logins.
 	Logins []SessionDataLogin `json:"logins,omitempty"`
 	// Token contains the issued token from a successful authentication flow.
-	Token *oidc.MarshaledToken `json:"token,omitempty"`
+	Token *oidc.TokenWithID `json:"token,omitempty"`
 }
 
 type SessionDataLogin struct {
@@ -264,7 +264,7 @@ func (h *Handler) authenticateCallback(r *http.Request, session *SessionData) (s
 		return "", fmt.Errorf("verifying id_token failed: %w", err)
 	}
 
-	session.Token = &oidc.MarshaledToken{Token: token}
+	session.Token = &oidc.TokenWithID{Token: token}
 
 	returnTo := foundLogin.ReturnTo
 	if returnTo == "" {

--- a/oauth2_options.go
+++ b/oauth2_options.go
@@ -28,6 +28,13 @@ const (
 	ScopeOfflineAccess = "offline_access"
 )
 
+const (
+	ACRMultiFactor         string = "http://schemas.openid.net/pape/policies/2007/06/multi-factor"
+	ACRMultiFactorPhysical string = "http://schemas.openid.net/pape/policies/2007/06/multi-factor-physical"
+
+	AMROTP string = "otp"
+)
+
 func SetACRValues(acrValues []string) oauth2.AuthCodeOption {
 	return oauth2.SetAuthURLParam("acr_values", strings.Join(acrValues, " "))
 }

--- a/provider.go
+++ b/provider.go
@@ -301,7 +301,7 @@ type IDTokenValidationOpts struct {
 // returned. Options should either have an audience specified, or have audience
 // validation opted out of.
 func (p *Provider) VerifyIDToken(ctx context.Context, tok *oauth2.Token, opts IDTokenValidationOpts) (*jwt.VerifiedJWT, *IDClaims, error) {
-	idt, ok := IDToken(tok)
+	idt, ok := GetIDToken(tok)
 	if !ok {
 		return nil, nil, fmt.Errorf("token does not contain an ID token")
 	}

--- a/provider_test.go
+++ b/provider_test.go
@@ -165,7 +165,7 @@ func TestIDTokenVerification(t *testing.T) {
 			}
 			signed := signRawJWT(t, h, jwt)
 
-			o2t := TokenWithID(&oauth2.Token{}, signed)
+			o2t := AddIDToken(&oauth2.Token{}, signed)
 
 			_, gotc, err := provider.VerifyIDToken(context.TODO(), o2t, tc.VerifOpts)
 			if (err != nil && tc.WantErrStr == "") || (err == nil && tc.WantErrStr != "") || (err != nil && !strings.Contains(err.Error(), tc.WantErrStr)) {

--- a/token.go
+++ b/token.go
@@ -7,25 +7,25 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// IDToken extracts the ID token from the given oauth2 Token
-func IDToken(tok *oauth2.Token) (string, bool) {
+// GetIDToken extracts the ID token from the given oauth2 Token
+func GetIDToken(tok *oauth2.Token) (string, bool) {
 	idt, ok := tok.Extra("id_token").(string)
 	return idt, ok
 }
 
-// TokenWithID reconstructs the oauth2 token, with the ID token added. This
+// AddIDToken reconstructs the oauth2 token, with the ID token added. This
 // exists because the serialized form of the oauth2 token does not contain the
 // extra/ID token info, so this safely allows a token to be stored and t
-func TokenWithID(tok *oauth2.Token, idToken string) *oauth2.Token {
+func AddIDToken(tok *oauth2.Token, idToken string) *oauth2.Token {
 	return tok.WithExtra(map[string]any{
 		"id_token": idToken,
 	})
 }
 
-// MarshaledToken is a wrapper for an oauth2 token, that allows the ID Token to
+// TokenWithID is a wrapper for an oauth2 token, that allows the ID Token to
 // be serialized as well if present. This is used when a token needs to be
 // saved/restored.
-type MarshaledToken struct {
+type TokenWithID struct {
 	*oauth2.Token
 }
 
@@ -35,7 +35,7 @@ type marshaledToken struct {
 	IDToken string `json:"id_token,omitempty"`
 }
 
-func (t *MarshaledToken) UnmarshalJSON(b []byte) error {
+func (t *TokenWithID) UnmarshalJSON(b []byte) error {
 	if t == nil {
 		return errors.New("UnmarshalJSON: destination pointer is nil")
 	}
@@ -45,13 +45,13 @@ func (t *MarshaledToken) UnmarshalJSON(b []byte) error {
 	}
 	t.Token = mt.Token
 	if mt.IDToken != "" {
-		t.Token = TokenWithID(t.Token, mt.IDToken)
+		t.Token = AddIDToken(t.Token, mt.IDToken)
 	}
 	return nil
 }
 
-func (t MarshaledToken) MarshalJSON() ([]byte, error) {
-	idt, _ := IDToken(t.Token)
+func (t TokenWithID) MarshalJSON() ([]byte, error) {
+	idt, _ := GetIDToken(t.Token)
 	mt := marshaledToken{
 		Token:   t.Token,
 		IDToken: idt,

--- a/token_test.go
+++ b/token_test.go
@@ -18,14 +18,14 @@ func TestMarshaledToken(t *testing.T) {
 	}
 	in = in.WithExtra(map[string]any{"id_token": "cccccc"})
 
-	mt := &MarshaledToken{in}
+	mt := &TokenWithID{in}
 
 	b, err := json.Marshal(mt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got := new(MarshaledToken)
+	got := new(TokenWithID)
 	if err := json.Unmarshal(b, got); err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func TestMarshaledToken(t *testing.T) {
 		t.Error(diff)
 	}
 
-	idt, ok := IDToken(got.Token)
+	idt, ok := GetIDToken(got.Token)
 	if !ok || idt != "cccccc" {
 		t.Errorf("want idt to exist and be cccccc, got: %s (exist %t)", idt, ok)
 	}

--- a/tokencache/cache.go
+++ b/tokencache/cache.go
@@ -78,7 +78,7 @@ func (k *KeychainCredentialCache) Get(issuer string, clientID string, scopes []s
 		return nil, fmt.Errorf("%s: %w", string(out), err)
 	}
 
-	var token oidc.MarshaledToken
+	var token oidc.TokenWithID
 	if err := json.Unmarshal(out, &token); err != nil {
 		return nil, fmt.Errorf("failed to decode token: %w", err)
 	}
@@ -87,7 +87,7 @@ func (k *KeychainCredentialCache) Get(issuer string, clientID string, scopes []s
 }
 
 func (k *KeychainCredentialCache) Set(issuer string, clientID string, scopes []string, acrValues []string, token *oauth2.Token) error {
-	b, err := json.Marshal(oidc.MarshaledToken{Token: token})
+	b, err := json.Marshal(oidc.TokenWithID{Token: token})
 	if err != nil {
 		return fmt.Errorf("failed to encode token: %w", err)
 	}


### PR DESCRIPTION
This re-works the local token source, to be more in-line with x/oauth2. The setup is moved in to a config struct, which has the ability to return a tokensource. The auth code options are exposed, allowing customization in a standard way. A happy-path test is added.

A few cleanups around token with ID token are added.
