### PR TITLE
Add README, update ID token source expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # oidc
 
-Experimental OIDC library, for server and client use.
+[![Go Reference](https://pkg.go.dev/badge/github.com/lstoll/oidc.svg)](https://pkg.go.dev/github.com/lstoll/oidc)
+
+Module that provides extensions for OIDC usage with [x/oauth2](https://pkg.go.dev/golang.org/x/oauth2), as well as some other extended oauth2 usage.
+
+The root package provides functions around interacting with an OIDC provider. The provider can be discovered from the issuer URL, or manually configured. The provider instance can be used to verify the issued ID tokens, and access tokens if they comply with the [JWT Profile](https://datatracker.ietf.org/doc/html/rfc9068).
+
+Some other packages are provided:
+* [**clitoken**](https://pkg.go.dev/github.com/lstoll/oidc/clitoken) Implements the three-legged OIDC flow for local/CLI applications, with a dynamic server on the loopback to handle the callback
+* [**middleware**](https://pkg.go.dev/github.com/lstoll/oidc/middleware) Provides a HTTP middleware to secure a path against an OIDC issuer
+* [**tokencache**](https://pkg.go.dev/github.com/lstoll/oidc/tokencache) Provides a mechanism for caching and refreshing tokens.
+
+Examples:
+* **cmd/oidc-example-rp** An example of a webapp that authenticates via OIDC
+* **cmd/oidcli** A CLI tool that uses the [clitoken](https://pkg.go.dev/github.com/lstoll/oidc/clitoken) package to retrieve ID/Access tokens, and return them or information about them.

--- a/id_token_source.go
+++ b/id_token_source.go
@@ -1,38 +1,57 @@
 package oidc
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
 	"golang.org/x/oauth2"
 )
-
-type idTokenSource struct {
-	wrapped oauth2.TokenSource
-}
 
 // NewIDTokenSource wraps a token source, re-writing the ID token as the access
 // token for outgoing requests. This is a backwards compatibility option for
 // services that expect the ID token contents, or where the access token is not
 // a JWT/not otherwise verifiable. It should be the _last_ token source in any
-// chain, the result from this should not be cached.
+// chain, the result from this should not be cached. Provider is optional, if
+// provided it will be used to set the token expiry based on the issued token's
+// expiry. If nil, the oauth2 token endpoint expiration will be used, which may
+// or may not correlate with the ID token's expiration.
 //
 // Deprecated: Services should expect oauth2 access tokens, and use the userinfo
-// endpoint if profile information is required.
-func NewIDTokenSource(ts oauth2.TokenSource) oauth2.TokenSource {
-	return &idTokenSource{}
+// endpoint if profile information is required. This will not be removed, but is
+// marked as deprecated to require explcit opt-in for linting etc.
+func NewIDTokenSource(ts oauth2.TokenSource, provider *Provider) oauth2.TokenSource {
+	return &idTokenSource{wrapped: ts, provider: provider}
+}
+
+type idTokenSource struct {
+	mu       sync.Mutex
+	wrapped  oauth2.TokenSource
+	provider *Provider
 }
 
 func (i *idTokenSource) Token() (*oauth2.Token, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	t, err := i.wrapped.Token()
 	if err != nil {
 		return nil, fmt.Errorf("getting token from wrapped source: %w", err)
 	}
 	idt, ok := t.Extra("id_token").(string)
-	if ok {
+	if ok || idt == "" {
 		return nil, fmt.Errorf("token contains no id_token")
 	}
 	newToken := new(oauth2.Token)
 	*newToken = *t
 	newToken.AccessToken = idt
+	if i.provider != nil {
+		_, cl, err := i.provider.VerifyIDToken(context.TODO(), t, IDTokenValidationOpts{IgnoreAudience: true})
+		if err != nil {
+			return nil, fmt.Errorf("verifying id token: %w", err)
+		}
+		newToken.ExpiresIn = 0
+		newToken.Expiry = cl.Expiry.Time()
+	}
 	return newToken, nil
 }


### PR DESCRIPTION
Start a more useful README.

Update the ID token source to clarify why it's marked as deprecated, and make its expiration calculation more accurate if a provider is provided.