### PR TITLE
Fix ID Token Source logic, Test keyset with multiple key types

### DIFF
--- a/id_token_source.go
+++ b/id_token_source.go
@@ -39,7 +39,7 @@ func (i *idTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("getting token from wrapped source: %w", err)
 	}
 	idt, ok := t.Extra("id_token").(string)
-	if ok || idt == "" {
+	if !ok || idt == "" {
 		return nil, fmt.Errorf("token contains no id_token")
 	}
 	newToken := new(oauth2.Token)

--- a/multitype_jwks_test.go
+++ b/multitype_jwks_test.go
@@ -1,0 +1,109 @@
+package oidc
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+)
+
+func TestMultitypeJWKS(t *testing.T) {
+	// we want to support servers that have keys of multiple types. See how tink
+	// handles this/
+	rsah, err := keyset.NewHandle(jwt.RS256_2048_F4_Key_Template())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsapubh, err := rsah.Public()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsajwks, err := jwt.JWKSetFromPublicKeysetHandle(rsapubh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ech, err := keyset.NewHandle(jwt.ES256Template())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecpubh, err := ech.Public()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecjwks, err := jwt.JWKSetFromPublicKeysetHandle(ecpubh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("rsa jwks: %s", string(rsajwks))
+	t.Logf("ec jwks: %s", string(ecjwks))
+
+	mergejwksm := make(map[string]any)
+	if err := json.Unmarshal(rsajwks, &mergejwksm); err != nil {
+		t.Fatal(err)
+	}
+	ecjwksm := make(map[string]any)
+	if err := json.Unmarshal(ecjwks, &ecjwksm); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range ecjwksm["keys"].([]any) {
+		mergejwksm["keys"] = append(mergejwksm["keys"].([]any), k)
+	}
+	mergejwks, err := json.Marshal(mergejwksm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("merged jwks: %s", string(mergejwks))
+
+	mergeh, err := jwt.JWKSetToPublicKeysetHandle(mergejwks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mergeVerif, err := jwt.NewVerifier(mergeh)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawjwt, err := jwt.NewRawJWT(&jwt.RawJWTOptions{
+		Issuer:    ptr("https://test"),
+		Audience:  ptr("test"),
+		ExpiresAt: ptr(time.Now().Add(1 * time.Minute)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rsasigner, err := jwt.NewSigner(rsah)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecsigner, err := jwt.NewSigner(ech)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signedrsa, err := rsasigner.SignAndEncode(rawjwt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedec, err := ecsigner.SignAndEncode(rawjwt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validator, err := jwt.NewValidator(&jwt.ValidatorOpts{
+		ExpectedIssuer:   ptr("https://test"),
+		ExpectedAudience: ptr("test"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, signed := range []string{signedrsa, signedec} {
+		if _, err := mergeVerif.VerifyAndDecode(signed, validator); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/provider.go
+++ b/provider.go
@@ -394,7 +394,9 @@ func (s *staticPublicHandle) PublicHandle(context.Context) (*keyset.Handle, erro
 	return s.h, nil
 }
 
-// NewStaticPublicHandle creates a PublicHandle from a fixed keyset Handle.
+// NewStaticPublicHandle creates a PublicHandle from a fixed keyset Handle. This
+// handle is used for JWT verification, so must be for a JWT type and contain
+// the public keys only.
 func NewStaticPublicHandle(h *keyset.Handle) PublicHandle {
 	return &staticPublicHandle{h: h}
 }


### PR DESCRIPTION
Fix the logic bug in the ID token source.

Test verifying against a JWKS with multiple key types in tink, we want to be able to do this soon.