### PR TITLE
clitoken cache: Use native Keychain API if available

### DIFF
--- a/.github/workflows/go-macos.yml
+++ b/.github/workflows/go-macos.yml
@@ -1,0 +1,47 @@
+name: Go
+on: [push]
+jobs:
+
+  build:
+    name: "Build (macOS) - CGO_ENABLED: ${{ matrix.envs.CGO_ENABLED }}"
+    runs-on: macos-latest
+    strategy:
+      # we use a matrix because the two test types don't interact well -
+      # keychain permissions will pop up a dialog to allow access, and we can't
+      # approve that.
+      matrix:
+        envs:
+        - CGO_ENABLED: 0
+        - CGO_ENABLED: 1
+    env:
+      GOTOOLCHAIN: local
+
+    steps:
+
+    - name: Print CGO_ENABLED
+      env:
+        CGO_ENABLED: ${{ matrix.envs.CGO_ENABLED }}
+      run: echo "CGO_ENABLED is $CGO_ENABLED"
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+      id: go
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Build
+      run: go build ./...
+      env:
+        CGO_ENABLED: ${{ matrix.envs.CGO_ENABLED }}
+
+    - name: Test
+      run: go test -timeout=15s -v ./...
+      env:
+        CGO_ENABLED: ${{ matrix.envs.CGO_ENABLED }}
+        TEST_KEYCHAIN_CREDENTIAL_CACHE: 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go mod download
@@ -35,3 +35,11 @@ jobs:
       uses: golangci/golangci-lint-action@v6
       with:
         version: latest
+
+    - name: Check CLI Keychain in cross-compiled binary
+      env:
+        GOOS: darwin
+        CGO_ENABLED: 0
+      run: |
+        go build -o oidccli ./cmd/oidccli
+        go tool nm oidccli | grep -F 'oidc/clitoken.(*KeychainCLICredentialCache)'

--- a/clitoken/cache_darwin_cgo.go
+++ b/clitoken/cache_darwin_cgo.go
@@ -1,0 +1,169 @@
+//go:build darwin && cgo
+
+package clitoken
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+CFStringRef GoStringToCFStringRef(const char *str) {
+	return CFStringCreateWithCString(kCFAllocatorDefault, str, kCFStringEncodingUTF8);
+}
+
+int set_keychain_password(const char *service, const char *account, const char *password) {
+	CFStringRef serviceRef = GoStringToCFStringRef(service);
+	CFStringRef accountRef = GoStringToCFStringRef(account);
+	CFDataRef passwordRef = CFDataCreate(kCFAllocatorDefault, (const UInt8 *)password, strlen(password));
+
+	// Create a query dictionary to search for an existing item
+	CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+	CFDictionarySetValue(query, kSecAttrService, serviceRef);
+	CFDictionarySetValue(query, kSecAttrAccount, accountRef);
+
+	// Create a dictionary with the new password to update
+	CFMutableDictionaryRef update = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(update, kSecValueData, passwordRef);
+
+	OSStatus status = SecItemUpdate(query, update);
+	if (status == errSecItemNotFound) {
+		CFDictionarySetValue(query, kSecValueData, passwordRef);
+		status = SecItemAdd(query, NULL);
+	}
+
+	CFRelease(query);
+	CFRelease(update);
+	CFRelease(serviceRef);
+	CFRelease(accountRef);
+	CFRelease(passwordRef);
+
+	return status;
+}
+
+int get_keychain_password(const char *service, const char *account, char **password) {
+	CFStringRef serviceRef = GoStringToCFStringRef(service);
+	CFStringRef accountRef = GoStringToCFStringRef(account);
+
+	CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+	CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+	CFDictionarySetValue(query, kSecAttrService, serviceRef);
+	CFDictionarySetValue(query, kSecAttrAccount, accountRef);
+	CFDictionarySetValue(query, kSecReturnData, kCFBooleanTrue);
+	CFDictionarySetValue(query, kSecMatchLimit, kSecMatchLimitOne);
+
+	CFDataRef result = NULL;
+	OSStatus status = SecItemCopyMatching(query, (CFTypeRef *)&result);
+
+	if (status == errSecSuccess) {
+		long length = CFDataGetLength(result);
+		*password = (char *)malloc(length + 1);
+		if (*password == NULL) {
+			abort();
+		}
+		memcpy(*password, CFDataGetBytePtr(result), length);
+		(*password)[length] = '\0';
+		CFRelease(result);
+	}
+
+	CFRelease(query);
+	CFRelease(serviceRef);
+	CFRelease(accountRef);
+
+	return status;
+}
+*/
+import "C"
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"unsafe"
+
+	"github.com/lstoll/oidc"
+	"github.com/lstoll/oidc/tokencache"
+	"golang.org/x/oauth2"
+)
+
+func init() {
+	platformCaches = append(platformCaches, &KeychainCredentialCache{})
+}
+
+var (
+	nilCFStringRef C.CFStringRef
+)
+
+type keychainError struct {
+	status C.OSStatus
+}
+
+func (e *keychainError) Error() string {
+	cfError := C.SecCopyErrorMessageString(e.status, nil)
+	if cfError != nilCFStringRef {
+		defer C.CFRelease(C.CFTypeRef(cfError))
+		return C.GoString(C.CFStringGetCStringPtr(cfError, C.kCFStringEncodingUTF8))
+	}
+	return fmt.Sprintf("Unknown keychain error: %d", e.status)
+}
+
+func newKeychainError(status C.OSStatus) error {
+	if status == C.errSecSuccess {
+		return nil
+	}
+	return &keychainError{status: status}
+}
+
+type KeychainCredentialCache struct{}
+
+var _ tokencache.CredentialCache = &KeychainCredentialCache{}
+
+func (k *KeychainCredentialCache) Get(issuer, key string) (*oauth2.Token, error) {
+	service := C.CString(issuer)
+	account := C.CString(key)
+	var result *C.char
+	status := C.get_keychain_password(service, account, &result)
+	C.free(unsafe.Pointer(service))
+	C.free(unsafe.Pointer(account))
+
+	if status == C.errSecItemNotFound { // no pw found
+		return nil, nil
+	} else if err := newKeychainError(status); err != nil {
+		return nil, fmt.Errorf("reading password from keychain: %w", err)
+	}
+
+	password := C.GoString(result)
+	C.free(unsafe.Pointer(result))
+
+	var token oidc.TokenWithID
+	if err := json.Unmarshal([]byte(password), &token); err != nil {
+		return nil, fmt.Errorf("failed to decode token: %w", err)
+	}
+
+	return token.Token, nil
+}
+
+func (k *KeychainCredentialCache) Set(issuer, key string, token *oauth2.Token) error {
+	b, err := json.Marshal(oidc.TokenWithID{Token: token})
+	if err != nil {
+		return fmt.Errorf("failed to encode token: %w", err)
+	}
+
+	service := C.CString(issuer)
+	account := C.CString(key)
+	password := C.CString(string(b))
+	status := C.set_keychain_password(service, account, password)
+	C.free(unsafe.Pointer(service))
+	C.free(unsafe.Pointer(account))
+	C.free(unsafe.Pointer(password))
+
+	if err := newKeychainError(status); err != nil {
+		return fmt.Errorf("setting password: %w", err)
+	}
+
+	return nil
+}
+
+func (k *KeychainCredentialCache) Available() bool {
+	// should always be this, but check anyway
+	return runtime.GOOS == "darwin"
+}

--- a/clitoken/cache_darwin_cgo_test.go
+++ b/clitoken/cache_darwin_cgo_test.go
@@ -1,0 +1,24 @@
+//go:build darwin && cgo
+
+package clitoken
+
+import (
+	"os"
+	"testing"
+)
+
+func TestKeychainCredentialCache(t *testing.T) {
+	// This test requires access to macOS Keychain
+	if os.Getenv("TEST_KEYCHAIN_CREDENTIAL_CACHE") == "" {
+		t.Skip("TEST_KEYCHAIN_CREDENTIAL_CACHE not set")
+		return
+	}
+
+	cache := &KeychainCredentialCache{}
+
+	if !cache.Available() {
+		t.Fatal("cache is not available")
+	}
+
+	testCache(t, cache)
+}

--- a/clitoken/cache_darwin_noncgo.go
+++ b/clitoken/cache_darwin_noncgo.go
@@ -1,0 +1,83 @@
+//go:build darwin && !cgo
+
+package clitoken
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/lstoll/oidc"
+	"github.com/lstoll/oidc/tokencache"
+	"golang.org/x/oauth2"
+)
+
+func init() {
+	platformCaches = append(platformCaches, &KeychainCLICredentialCache{})
+}
+
+type KeychainCLICredentialCache struct{}
+
+var _ tokencache.CredentialCache = &KeychainCLICredentialCache{}
+
+func (k *KeychainCLICredentialCache) Get(issuer, key string) (*oauth2.Token, error) {
+	cmd := exec.Command(
+		"/usr/bin/security",
+		"find-generic-password",
+		"-s", issuer,
+		"-a", key,
+		"-w",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if bytes.Contains(out, []byte("could not be found")) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("%s: %w", string(out), err)
+	}
+
+	var token oidc.TokenWithID
+	if err := json.Unmarshal(out, &token); err != nil {
+		return nil, fmt.Errorf("failed to decode token: %w", err)
+	}
+
+	return token.Token, nil
+}
+
+func (k *KeychainCLICredentialCache) Set(issuer, key string, token *oauth2.Token) error {
+	b, err := json.Marshal(oidc.TokenWithID{Token: token})
+	if err != nil {
+		return fmt.Errorf("failed to encode token: %w", err)
+	}
+
+	cmd := exec.Command(
+		"/usr/bin/security",
+		"add-generic-password",
+		"-s", issuer,
+		"-a", key,
+		"-w", string(b),
+		"-U",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", string(out), err)
+	}
+
+	return nil
+}
+
+func (k *KeychainCLICredentialCache) Available() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+
+	_, err := os.Stat("/usr/bin/security")
+
+	return err == nil
+}

--- a/clitoken/cache_darwin_noncgo_test.go
+++ b/clitoken/cache_darwin_noncgo_test.go
@@ -1,0 +1,24 @@
+//go:build darwin && !cgo
+
+package clitoken
+
+import (
+	"os"
+	"testing"
+)
+
+func TestKeychainCLICredentialCache(t *testing.T) {
+	// This test requires access to macOS Keychain
+	if os.Getenv("TEST_KEYCHAIN_CREDENTIAL_CACHE") == "" {
+		t.Skip("TEST_KEYCHAIN_CREDENTIAL_CACHE not set")
+		return
+	}
+
+	cache := &KeychainCLICredentialCache{}
+
+	if !cache.Available() {
+		t.Fatal("cache is not available")
+	}
+
+	testCache(t, cache)
+}

--- a/clitoken/cache_test.go
+++ b/clitoken/cache_test.go
@@ -10,18 +10,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func TestKeychainCredentialCache(t *testing.T) {
-	// This test requires access to macOS Keychain
-	if os.Getenv("TEST_KEYCHAIN_CREDENTIAL_CACHE") == "" {
-		t.Skip("TEST_KEYCHAIN_CREDENTIAL_CACHE not set")
-		return
-	}
-
-	cache := &KeychainCredentialCache{}
-
-	testCache(t, cache)
-}
-
 func TestEncryptedFileCredentialCache(t *testing.T) {
 	dir, err := os.MkdirTemp("", "cachetest")
 	if err != nil {


### PR DESCRIPTION
Shelling out to `/usr/bin/security` isn't the best, as any other process can call this to get the secret. If compiling in an environment that supports darwin/cgo, use the native APIs instead. This gives better control over the access of the data.