### PR TITLE
Better default cache key, fix oidccli

### DIFF
--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -11,7 +12,6 @@ import (
 	"github.com/lstoll/oidc"
 	"github.com/lstoll/oidc/clitoken"
 	"github.com/lstoll/oidc/tokencache"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -173,8 +173,11 @@ func main() {
 
 	if !baseFlags.SkipCache {
 		ccfg := tokencache.Config{
-			Issuer:        baseFlags.Issuer,
-			CacheKey:      (tokencache.IDTokenCacheKey{}).Key(),
+			Issuer: baseFlags.Issuer,
+			CacheKey: (tokencache.IDTokenCacheKey{
+				ClientID: baseFlags.ClientID,
+				Scopes:   scopes,
+			}).Key(),
 			WrappedSource: ts,
 			Cache:         clitoken.BestCredentialCache(),
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/tink-crypto/tink-go/v2 v2.2.0
 	golang.org/x/crypto v0.30.0
-	golang.org/x/net v0.32.0
 	golang.org/x/oauth2 v0.24.0
 	golang.org/x/term v0.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/tink-crypto/tink-go/v2 v2.2.0 h1:L2Da0F2Udh2agtKztdr69mV/KpnY3/lGTkMg
 github.com/tink-crypto/tink-go/v2 v2.2.0/go.mod h1:JJ6PomeNPF3cJpfWC0lgyTES6zpJILkAX0cJNwlS3xU=
 golang.org/x/crypto v0.30.0 h1:RwoQn3GkWiMkzlX562cLB7OxWvjH1L8xutO2WoJcRoY=
 golang.org/x/crypto v0.30.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
 golang.org/x/oauth2 v0.24.0 h1:KTBBxWqUa0ykRPLtV69rRto9TLXcqYkeswu48x/gvNE=
 golang.org/x/oauth2 v0.24.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=

--- a/tokencache/cache_token_source.go
+++ b/tokencache/cache_token_source.go
@@ -17,7 +17,8 @@ type Config struct {
 	// that the correct token is retrieved. e.g it should reflect the client ID,
 	// scopes, and any other authentication context used to obtain the token.
 	// Helper methods are provided to calculate this. Helpers functions are
-	// provided to calculate this.
+	// provided to calculate this. If not provided, the client ID will be used
+	// from the Oauth2Config if set. Otherwise, an error will occur.
 	CacheKey string
 	// WrappedSource is the oauth2.TokenSource we retrieve tokens to cache from.
 	WrappedSource oauth2.TokenSource
@@ -50,7 +51,10 @@ func (c *Config) TokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 		validErr = errors.Join(validErr, fmt.Errorf("issuer must be specified"))
 	}
 	if c.CacheKey == "" {
-		validErr = errors.Join(validErr, fmt.Errorf("cache key must be specified"))
+		if c.OAuth2Config == nil || c.OAuth2Config.ClientID == "" {
+			validErr = errors.Join(validErr, fmt.Errorf("cache key must be specified when oauth2 config not provided, or it has no client ID"))
+		}
+		c.CacheKey = c.OAuth2Config.ClientID
 	}
 	if c.WrappedSource == nil {
 		validErr = errors.Join(validErr, fmt.Errorf("a wrapped TokenSource must be provided"))


### PR DESCRIPTION
If a cache key is not set, try and figure one out by the client ID.

Fix the oidccli to actually generate a cache key.

Also fix old context reference.