### PR TITLE
Fetch userinfo with HTTP client if provided

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -322,9 +322,10 @@ func (p *Provider) Userinfo(ctx context.Context, tokenSource oauth2.TokenSource)
 		return nil, nil, fmt.Errorf("provider does not have a userinfo endpoint")
 	}
 
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, p.getHTTPClient())
 	oc := oauth2.NewClient(ctx, tokenSource)
 
-	req, err := http.NewRequest("GET", p.Metadata.UserinfoEndpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", p.Metadata.UserinfoEndpoint, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating identity fetch request: %v", err)
 	}


### PR DESCRIPTION
The Userinfo fetch was not using the provider's HTTP client, use it for the request.