### PR TITLE
Refresh cached token before expiry, clitoken only responds to GET

### DIFF
--- a/clitoken/cache_test.go
+++ b/clitoken/cache_test.go
@@ -102,7 +102,6 @@ func testCache(t *testing.T, cache tokencache.CredentialCache) {
 			want: nil,
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := tc.run(cache)
 			if err != nil {

--- a/middleware/cookie_state.go
+++ b/middleware/cookie_state.go
@@ -73,8 +73,8 @@ func (c *Cookiestore) GetOIDCSession(r *http.Request) (*SessionData, error) {
 
 	// Reconstruct login states from individual cookies
 	for _, cookie := range r.Cookies() {
-		if strings.HasPrefix(cookie.Name, opts.LoginStateCookiePrefix) {
-			state := strings.TrimPrefix(cookie.Name, opts.LoginStateCookiePrefix)
+		if after, ok := strings.CutPrefix(cookie.Name, opts.LoginStateCookiePrefix); ok {
+			state := after
 			if state == "" {
 				continue // Should not happen with a proper prefix
 			}
@@ -160,8 +160,8 @@ func (c *Cookiestore) SaveOIDCSession(w http.ResponseWriter, r *http.Request, d 
 
 	// Iterate through existing cookies to update or delete
 	for _, cookie := range r.Cookies() {
-		if strings.HasPrefix(cookie.Name, c.getCookieOpts().LoginStateCookiePrefix) {
-			state := strings.TrimPrefix(cookie.Name, c.getCookieOpts().LoginStateCookiePrefix)
+		if after, ok := strings.CutPrefix(cookie.Name, c.getCookieOpts().LoginStateCookiePrefix); ok {
+			state := after
 			if _, isActive := activeLoginStates[state]; !isActive {
 				// This state is no longer active or was truncated, delete its cookie
 				_ = setCookieIfNotSet(w, r, c.newLoginStateCookie(state, "", "", 0))

--- a/tokencache/cache_token_source_test.go
+++ b/tokencache/cache_token_source_test.go
@@ -14,6 +14,19 @@ type staticTokenSource struct {
 	token string
 }
 
+type mockTokenSource struct {
+	token     string
+	callCount int
+}
+
+func (m *mockTokenSource) Token() (*oauth2.Token, error) {
+	m.callCount++
+	return &oauth2.Token{
+		AccessToken: m.token,
+		Expiry:      time.Now().Add(1 * time.Minute),
+	}, nil
+}
+
 type memCache struct {
 	cache map[string]oauth2.Token
 }
@@ -45,35 +58,148 @@ func (s *staticTokenSource) Token() (*oauth2.Token, error) {
 }
 
 func TestCacheTokenSource(t *testing.T) {
-	tok := "hello"
-	cfg := Config{
-		Issuer:        "https://iss",
-		CacheKey:      "client",
-		WrappedSource: &staticTokenSource{token: tok},
-		Cache:         &memCache{cache: make(map[string]oauth2.Token)},
+	tests := []struct {
+		name        string
+		setupCache  func(*memCache)
+		earlyExpiry time.Duration
+		wantToken   string
+		wantCached  bool // whether we expect the token to come from cache vs wrapped source
+	}{
+		{
+			name: "no cached token - fetches from wrapped source",
+			setupCache: func(cache *memCache) {
+				// No token in cache
+			},
+			earlyExpiry: DefaultEarlyExpiry,
+			wantToken:   "fresh_token",
+			wantCached:  false,
+		},
+		{
+			name: "valid cached token - returns cached token",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "cached_token",
+					Expiry:      time.Now().Add(2 * time.Minute),
+				}
+			},
+			earlyExpiry: DefaultEarlyExpiry,
+			wantToken:   "cached_token",
+			wantCached:  true,
+		},
+		{
+			name: "expired cached token - fetches from wrapped source",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "expired_token",
+					Expiry:      time.Now().Add(-1 * time.Minute),
+				}
+			},
+			earlyExpiry: DefaultEarlyExpiry,
+			wantToken:   "fresh_token",
+			wantCached:  false,
+		},
+		{
+			name: "token within grace period - fetches from wrapped source",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "grace_period_token",
+					Expiry:      time.Now().Add(15 * time.Second),
+				}
+			},
+			earlyExpiry: DefaultEarlyExpiry,
+			wantToken:   "fresh_token",
+			wantCached:  false,
+		},
+		{
+			name: "token outside grace period - returns cached token",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "valid_token",
+					Expiry:      time.Now().Add(45 * time.Second),
+				}
+			},
+			earlyExpiry: DefaultEarlyExpiry,
+			wantToken:   "valid_token",
+			wantCached:  true,
+		},
+		{
+			name: "custom grace period - token within custom grace period",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "custom_grace_token",
+					Expiry:      time.Now().Add(10 * time.Second),
+				}
+			},
+			earlyExpiry: 20 * time.Second,
+			wantToken:   "fresh_token",
+			wantCached:  false,
+		},
+		{
+			name: "custom grace period - token outside custom grace period",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "custom_valid_token",
+					Expiry:      time.Now().Add(30 * time.Second),
+				}
+			},
+			earlyExpiry: 20 * time.Second,
+			wantToken:   "custom_valid_token",
+			wantCached:  true,
+		},
+		{
+			name: "zero grace period defaults to default grace period",
+			setupCache: func(cache *memCache) {
+				cache.cache["https://issuerclient"] = oauth2.Token{
+					AccessToken: "zero_grace_token",
+					Expiry:      time.Now().Add(1 * time.Second),
+				}
+			},
+			earlyExpiry: 0,
+			wantToken:   "fresh_token",
+			wantCached:  false,
+		},
 	}
 
-	ts, err := cfg.TokenSource(context.TODO())
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := &memCache{cache: make(map[string]oauth2.Token)}
+			tt.setupCache(cache)
 
-	gotTok, err := ts.Token()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotTok.AccessToken != tok {
-		t.Fatal("unexpected token")
-	}
+			mockSource := &mockTokenSource{token: "fresh_token"}
 
-	// will make us panic if no cache
-	ts.(*cachingTokenSource).cfg.WrappedSource = nil
+			cfg := Config{
+				Issuer:        "https://issuer",
+				CacheKey:      "client",
+				WrappedSource: mockSource,
+				Cache:         cache,
+				EarlyExpiry:   tt.earlyExpiry,
+			}
 
-	gotTok, err = ts.Token()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotTok.AccessToken != tok {
-		t.Fatal("unexpected token")
+			ts, err := cfg.TokenSource(context.TODO())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Reset call count before getting token
+			mockSource.callCount = 0
+
+			gotTok, err := ts.Token()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if gotTok.AccessToken != tt.wantToken {
+				t.Errorf("got token %q, want %q", gotTok.AccessToken, tt.wantToken)
+			}
+
+			// Verify cache behavior by checking if wrapped source was called
+			// If we expect cached token, wrapped source should not be called
+			// If we expect fresh token, wrapped source should be called
+			if tt.wantCached && mockSource.callCount > 0 {
+				t.Errorf("expected cached token but wrapped source was called %d times", mockSource.callCount)
+			} else if !tt.wantCached && mockSource.callCount == 0 {
+				t.Error("expected fresh token but wrapped source was not called")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Using a token up to its expiration time can cause issues when a close to expiry token is returned, and it expires before it is actually used. Clock skew can also aggregate that. Add a period of time before the actual expiry where the token cache will retrieve a fresh token.

Make the CLI callback handler respond to GET only. We've seen cases where a CORS preflight is fired, which trips the counter and makes us reject the actual callback.