### PR TITLE
Correctly handle single audiences, oidccli defaults to the ID token

### DIFF
--- a/claims/at_claims.go
+++ b/claims/at_claims.go
@@ -202,10 +202,14 @@ func (a *RawAccessTokenClaims) ToRawJWT() (*jwt.RawJWT, error) {
 		TypeHeader: th.Ptr(JWTTYPAccessToken),
 		Issuer:     th.PtrOrNil(a.Issuer),
 		Subject:    th.PtrOrNil(a.Subject),
-		Audiences:  a.Audience,
 		ExpiresAt:  exp,
 		JWTID:      th.PtrOrNil(a.JWTID),
 		IssuedAt:   iat,
+	}
+	if len(a.Audience) == 1 {
+		opts.Audience = th.Ptr(a.Audience[0])
+	} else if len(a.Audience) > 1 {
+		opts.Audiences = a.Audience
 	}
 
 	// Use a temp map to not modify the CustomClaims map directly

--- a/claims/id_claims.go
+++ b/claims/id_claims.go
@@ -205,10 +205,14 @@ func (i *RawIDClaims) ToRawJWT() (*jwt.RawJWT, error) {
 	opts := &jwt.RawJWTOptions{
 		Issuer:    th.PtrOrNil(i.Issuer),
 		Subject:   th.PtrOrNil(i.Subject),
-		Audiences: i.Audience,
 		ExpiresAt: exp,
 		NotBefore: nbf,
 		IssuedAt:  iat,
+	}
+	if len(i.Audience) == 1 {
+		opts.Audience = th.Ptr(i.Audience[0])
+	} else if len(i.Audience) > 1 {
+		opts.Audiences = i.Audience
 	}
 	opts.CustomClaims = make(map[string]any)
 

--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -32,11 +32,11 @@ type baseOpts struct {
 }
 
 type rawOpts struct {
-	UseIDToken bool
+	UseAccessToken bool
 }
 
 type kubeOpts struct {
-	UseIDToken bool
+	UseAccessToken bool
 }
 
 type infoOpts struct{}
@@ -59,7 +59,7 @@ func main() {
 
 	rawFlags := rawOpts{}
 	rawFs := flag.NewFlagSet("raw", flag.ExitOnError)
-	rawFs.BoolVar(&rawFlags.UseIDToken, "use-id-token", rawFlags.UseIDToken, "Use ID token, rather than access token")
+	rawFs.BoolVar(&rawFlags.UseAccessToken, "use-access-token", rawFlags.UseAccessToken, "Use access token, rather than id_token")
 	subcommands = append(subcommands, &subCommand{
 		Flags:       rawFs,
 		Description: "Output a raw JWT for this client",
@@ -67,7 +67,7 @@ func main() {
 
 	kubeFlags := kubeOpts{}
 	kubeFs := flag.NewFlagSet("kubernetes", flag.ExitOnError)
-	kubeFs.BoolVar(&kubeFlags.UseIDToken, "use-id-token", kubeFlags.UseIDToken, "Use ID token, rather than access token")
+	kubeFs.BoolVar(&kubeFlags.UseAccessToken, "use-access-token", kubeFlags.UseAccessToken, "Use access token, rather than id_token")
 	subcommands = append(subcommands, &subCommand{
 		Flags:       kubeFs,
 		Description: "Output credentials in a format that can be consumed by kubectl/client-go",
@@ -225,7 +225,7 @@ func raw(ts oauth2.TokenSource, opts rawOpts) error {
 		return fmt.Errorf("fetching token: %v", err)
 	}
 	raw := tok.AccessToken
-	if opts.UseIDToken {
+	if !opts.UseAccessToken {
 		idt, ok := oidc.GetIDToken(tok)
 		if !ok {
 			return fmt.Errorf("response has no id_token")
@@ -260,7 +260,7 @@ func kubernetes(ts oauth2.TokenSource, opts kubeOpts) error {
 		return fmt.Errorf("fetching token: %v", err)
 	}
 	var raw = tok.AccessToken
-	if opts.UseIDToken {
+	if !opts.UseAccessToken {
 		idt, ok := oidc.GetIDToken(tok)
 		if !ok {
 			return fmt.Errorf("response has no id_token")


### PR DESCRIPTION
If we only have a single audience, set a single audience to avoid to being an unnecessary array.

The oidccli defaults to returning the OIDC ID Token. It is an OIDC CLI after all.