### PR TITLE
Keychain: Extract/clean keychain code, add delete/list

### DIFF
--- a/.github/workflows/go-macos.yml
+++ b/.github/workflows/go-macos.yml
@@ -41,6 +41,7 @@ jobs:
         go test ./...
       env:
         CGO_ENABLED: ${{ matrix.envs.CGO_ENABLED }}
+        TEST_KEYCHAIN: 1
 
     # The goal here is to test against the keychain. We expect the same binary
     # to be able to read existing data in repeated invocations, and a new binary

--- a/clitoken/cache_darwin_cgo.go
+++ b/clitoken/cache_darwin_cgo.go
@@ -2,23 +2,16 @@
 
 package clitoken
 
-/*
-#cgo LDFLAGS: -framework CoreFoundation -framework Security
-#include <CoreFoundation/CoreFoundation.h>
-#include <Security/Security.h>
-*/
-import "C"
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
-	"syscall"
-	"unsafe"
 
+	"github.com/lstoll/oauth2ext/internal/keychain"
 	"github.com/lstoll/oauth2ext/oidc"
 	"github.com/lstoll/oauth2ext/tokencache"
 	"golang.org/x/oauth2"
@@ -28,34 +21,78 @@ func init() {
 	platformCaches = append(platformCaches, &KeychainCredentialCache{})
 }
 
+type keychainCredentialAccount struct {
+	Issuer string `json:"issuer,omitzero"`
+	Key    string `json:"key,omitzero"`
+
+	// TODO - reconsider the interface for a token cache to include more fields?
+}
+
 // KeychainCredentialCache uses the macOS keychain to store items. Items are
 // keyed by the binary and issuer that they are for. It is intended for
 // short/ephemeral caching, entries created via different executables will be
 // removed rather than requiring the executable to be signed, or user input.
-type KeychainCredentialCache struct{}
+type KeychainCredentialCache struct {
+	// Service is the name of the service we use to store keychain items.
+	// If not set, defaults to clitoken.<binary-name>
+	Service string
+}
 
 var _ tokencache.CredentialCache = &KeychainCredentialCache{}
 
 func (k *KeychainCredentialCache) Get(issuer, key string) (*oauth2.Token, error) {
-	ei, err := getKeychainExecutableInfo(issuer)
+	binaryID, err := keychain.GetBinaryIdentity()
 	if err != nil {
-		return nil, fmt.Errorf("getting executable info: %w", err)
+		return nil, fmt.Errorf("getting binary identity: %w", err)
 	}
 
-	password, err := getKeychainPassword(ei.BinaryKey, ei.ServiceName, key)
+	accountB, err := json.Marshal(keychainCredentialAccount{
+		Issuer: issuer,
+		Key:    key,
+	})
 	if err != nil {
-		var kcErr *keychainError
+		return nil, fmt.Errorf("marshalling key: %w", err)
+	}
+
+	service, err := k.serviceName()
+	if err != nil {
+		return nil, fmt.Errorf("getting service name: %w", err)
+	}
+
+	attrs, err := keychain.GetGenericPasswordAttributes(keychain.GenericPasswordQuery{
+		Service: service,
+		Account: string(accountB),
+	})
+	if err != nil {
+		var kcErr *keychain.Error
 		if errors.As(err, &kcErr) {
-			if kcErr.status == C.errSecItemNotFound {
+			if kcErr.Code == keychain.KeychainErrorCodeItemNotFound {
 				// not found, just return nil
 				return nil, nil
 			}
 		}
-		return nil, fmt.Errorf("getting credential from keychain: %w", err)
+		return nil, fmt.Errorf("getting generic password attributes: %w", err)
+	}
+
+	if !bytes.Equal(attrs.GenericAttributes, []byte(binaryID)) {
+		// does not match this binary, delete and treat as not found
+		_ = keychain.DeleteGenericPassword(keychain.GenericPasswordQuery{
+			Service: service,
+			Account: string(accountB),
+		})
+		return nil, nil
+	}
+
+	tokenB, err := keychain.GetGenericPassword(keychain.GenericPasswordQuery{
+		Service: service,
+		Account: string(accountB),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting generic password: %w", err)
 	}
 
 	var token oidc.TokenWithID
-	if err := json.Unmarshal([]byte(password), &token); err != nil {
+	if err := json.Unmarshal(tokenB, &token); err != nil {
 		return nil, fmt.Errorf("failed to decode token: %w", err)
 	}
 
@@ -68,16 +105,145 @@ func (k *KeychainCredentialCache) Set(issuer, key string, token *oauth2.Token) e
 		return fmt.Errorf("failed to encode token: %w", err)
 	}
 
-	ei, err := getKeychainExecutableInfo(issuer)
+	service, err := k.serviceName()
 	if err != nil {
-		return fmt.Errorf("getting executable info: %w", err)
+		return fmt.Errorf("getting service name: %w", err)
 	}
 
-	// we make the label read a little better in the UI
-	lbl := fmt.Sprintf("%s: %s (%s)", ei.Name, issuer, key)
+	binaryID, err := keychain.GetBinaryIdentity()
+	if err != nil {
+		return fmt.Errorf("getting binary identity: %w", err)
+	}
 
-	if err := setKeychainPassword(ei.BinaryKey, lbl, ei.ServiceName, key, string(b)); err != nil {
+	accountB, err := json.Marshal(keychainCredentialAccount{
+		Issuer: issuer,
+		Key:    key,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling account: %w", err)
+	}
+
+	// delete any existing item with this account
+	if err := keychain.DeleteGenericPassword(keychain.GenericPasswordQuery{
+		Service: service,
+		Account: string(accountB),
+	}); err != nil {
+		var kcErr *keychain.Error
+		if !errors.As(err, &kcErr) || kcErr.Code != keychain.KeychainErrorCodeItemNotFound {
+			return fmt.Errorf("deleting existing item: %w", err)
+		}
+	}
+
+	if err := keychain.CreateGenericPassword(keychain.GenericPassword{
+		Service:           service,
+		Account:           string(accountB),
+		Label:             fmt.Sprintf("%s: %s (%s)", service, issuer, key),
+		GenericAttributes: []byte(binaryID),
+		Value:             b,
+	}); err != nil {
 		return fmt.Errorf("saving credential to keychain: %w", err)
+	}
+
+	return nil
+}
+
+// Delete deletes the item for the given issuer and key, if it exists.
+func (k *KeychainCredentialCache) Delete(issuer, key string) error {
+	service, err := k.serviceName()
+	if err != nil {
+		return fmt.Errorf("getting service name: %w", err)
+	}
+
+	accountB, err := json.Marshal(keychainCredentialAccount{
+		Issuer: issuer,
+		Key:    key,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling account: %w", err)
+	}
+
+	err = keychain.DeleteGenericPassword(keychain.GenericPasswordQuery{
+		Service: service,
+		Account: string(accountB),
+	})
+	if err != nil {
+		var kcErr *keychain.Error
+		if errors.As(err, &kcErr) {
+			if kcErr.Code == keychain.KeychainErrorCodeItemNotFound {
+				return nil
+			}
+		}
+		return fmt.Errorf("deleting credential from keychain: %w", err)
+	}
+
+	return nil
+}
+
+type KeychainListItem struct {
+	Issuer string
+	Key    string
+}
+
+// List returns all items in the keychain for this service.
+func (k *KeychainCredentialCache) List() ([]KeychainListItem, error) {
+	service, err := k.serviceName()
+	if err != nil {
+		return nil, fmt.Errorf("getting service name: %w", err)
+	}
+
+	binaryID, err := keychain.GetBinaryIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("getting binary identity: %w", err)
+	}
+
+	items, err := keychain.ListGenericPasswords(keychain.GenericPasswordQuery{
+		Service: service,
+	})
+	if err != nil {
+		var kcErr *keychain.Error
+		if errors.As(err, &kcErr) {
+			if kcErr.Code == keychain.KeychainErrorCodeItemNotFound {
+				// no items found, just return empty list
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("listing items from keychain: %w", err)
+	}
+
+	listItems := make([]KeychainListItem, 0, len(items))
+
+	for _, item := range items {
+		var account keychainCredentialAccount
+		if err := json.Unmarshal([]byte(item.Account), &account); err != nil {
+			return nil, fmt.Errorf("unmarshalling account: %w", err)
+		}
+		// skip items that we couldn't read
+		if !bytes.Equal(item.GenericAttributes, []byte(binaryID)) {
+			continue
+		}
+		listItems = append(listItems, KeychainListItem(account))
+	}
+
+	return listItems, nil
+}
+
+// DeleteAll deletes all items in the keychain for this service.
+func (k *KeychainCredentialCache) DeleteAll() error {
+	service, err := k.serviceName()
+	if err != nil {
+		return fmt.Errorf("getting service name: %w", err)
+	}
+
+	if err := keychain.DeleteGenericPassword(keychain.GenericPasswordQuery{
+		Service: service,
+	}); err != nil {
+		var kcErr *keychain.Error
+		if errors.As(err, &kcErr) {
+			if kcErr.Code == keychain.KeychainErrorCodeItemNotFound {
+				return nil
+			}
+		}
+		return fmt.Errorf("deleting all items from keychain for service %q: %w", service, err)
 	}
 
 	return nil
@@ -88,210 +254,14 @@ func (k *KeychainCredentialCache) Available() bool {
 	return runtime.GOOS == "darwin"
 }
 
-type keychainExecutableInfo struct {
-	// BinaryKey uniquely identifies this compiled binary by it's creation
-	// time.This is fast to get, and should uniquely represent the process that
-	// created the keychain entry.
-	BinaryKey []byte
-	// Name is the basename of this executable
-	Name string
-	// ServiceName is the issuer with an execuable-specific prefix, to handle
-	// multiple applications saving items for the same idp.
-	ServiceName string
-}
+func (k *KeychainCredentialCache) serviceName() (string, error) {
+	if k.Service != "" {
+		return k.Service, nil
+	}
 
-// getKeychainProcessInfo builds the process/binary specific info used for
-// accessing the keychain
-func getKeychainExecutableInfo(issuer string) (keychainExecutableInfo, error) {
 	execPath, err := os.Executable()
 	if err != nil {
-		return keychainExecutableInfo{}, fmt.Errorf("looking up executable: %w", err)
+		return "", fmt.Errorf("failed to get executable path: %w", err)
 	}
-
-	fileInfo, err := os.Stat(execPath)
-	if err != nil {
-		return keychainExecutableInfo{}, fmt.Errorf("getting executable info: %w", err)
-	}
-
-	stat := fileInfo.Sys().(*syscall.Stat_t)
-
-	bi := make([]byte, 8)
-	binary.LittleEndian.PutUint64(bi, uint64(stat.Ctimespec.Nano()))
-
-	return keychainExecutableInfo{
-		BinaryKey:   bi,
-		Name:        fileInfo.Name(),
-		ServiceName: fileInfo.Name() + ";" + issuer,
-	}, nil
-}
-
-var (
-	nilCFStringRef C.CFStringRef
-)
-
-type keychainError struct {
-	status C.OSStatus
-}
-
-func (e *keychainError) Error() string {
-	cfError := C.SecCopyErrorMessageString(e.status, nil)
-	if cfError != nilCFStringRef {
-		defer C.CFRelease(C.CFTypeRef(cfError))
-		return fmt.Sprintf("%s (%d)", cfStringToString(cfError), e.status)
-	}
-	return fmt.Sprintf("Unknown keychain error: %d", e.status)
-}
-
-func newKeychainError(status C.OSStatus) error {
-	if status == C.errSecSuccess {
-		return nil
-	}
-	return &keychainError{status: status}
-}
-
-// setKeychainPassword stores an item in the keychain. If it doesn't exist it
-// will be created, if it does the password field will be updated. binaryKey is
-// used to uniqely identify this compiled binary, to avoid prompting for unlock
-// when a different binary created the item.
-//
-//nolint:govet // the possible unsafe use is fine here
-func setKeychainPassword(binaryKey []byte, label, service, account, password string) error {
-	labelRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(label), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(labelRef))
-	serviceRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(service), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(serviceRef))
-	accountRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(account), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(accountRef))
-
-	passwordBytes := []byte(password)
-	passwordRef := C.CFDataCreate(C.kCFAllocatorDefault, (*C.UInt8)(unsafe.Pointer(&passwordBytes[0])), C.CFIndex(len(passwordBytes)))
-	defer C.CFRelease(C.CFTypeRef(passwordRef))
-
-	binaryKeyRef := C.CFDataCreate(C.kCFAllocatorDefault, (*C.UInt8)(unsafe.Pointer(&binaryKey[0])), C.CFIndex(len(binaryKey)))
-	defer C.CFRelease(C.CFTypeRef(binaryKeyRef))
-
-	// always try and delete the item first, to ensure it is set for our app. If
-	// we update, it doesn't seem to update the ACL as well.
-	if err := deleteKeychainPassword(service, account); err != nil {
-		var kcErr *keychainError
-		if !errors.As(err, &kcErr) || kcErr.status != C.errSecItemNotFound {
-			return fmt.Errorf("deleting keychain item: %w", err)
-		}
-	}
-
-	query := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
-	defer C.CFRelease(C.CFTypeRef(query))
-
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassGenericPassword))
-	// these two make up the primary key in the keychain
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrService), unsafe.Pointer(serviceRef))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrAccount), unsafe.Pointer(accountRef))
-	// and these are the fields we want to set
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrLabel), unsafe.Pointer(labelRef))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecValueData), unsafe.Pointer(passwordRef))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrGeneric), unsafe.Pointer(binaryKeyRef))
-	status := C.SecItemAdd(C.CFDictionaryRef(query), nil)
-
-	return newKeychainError(status)
-}
-
-//nolint:govet // the possible unsafe use is fine here
-func getKeychainPassword(binaryKey []byte, service, account string) (string, error) {
-	serviceRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(service), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(serviceRef))
-	accountRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(account), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(accountRef))
-
-	query := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
-	defer C.CFRelease(C.CFTypeRef(query))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassGenericPassword))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrService), unsafe.Pointer(serviceRef))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrAccount), unsafe.Pointer(accountRef))
-	// get the attributes first, so we can check if it aligns with this
-	// executable
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecReturnAttributes), unsafe.Pointer(C.kCFBooleanTrue))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecMatchLimit), unsafe.Pointer(C.kSecMatchLimitOne))
-
-	var result C.CFTypeRef
-	status := C.SecItemCopyMatching(C.CFDictionaryRef(query), &result)
-	if err := newKeychainError(status); err != nil {
-		return "", fmt.Errorf("reading from keychain: %w", err)
-	}
-	defer C.CFRelease(result)
-
-	count := C.CFDictionaryGetCount(C.CFDictionaryRef(result))
-	if count == 0 {
-		return "", fmt.Errorf("getting attribute info returned no items")
-	}
-
-	keys := make([]C.CFTypeRef, count)
-	values := make([]C.CFTypeRef, count)
-	C.CFDictionaryGetKeysAndValues(C.CFDictionaryRef(result), (*unsafe.Pointer)(unsafe.Pointer(&keys[0])), (*unsafe.Pointer)(unsafe.Pointer(&values[0])))
-	attrs := make(map[C.CFTypeRef]C.CFTypeRef, count)
-	for i := C.CFIndex(0); i < count; i++ {
-		attrs[keys[i]] = values[i]
-	}
-
-	abk, ok := attrs[C.CFTypeRef(C.kSecAttrGeneric)]
-	if !ok {
-		// record has no binary key, remove and treat as not found
-		_ = deleteKeychainPassword(service, account)
-		return "", newKeychainError(C.errSecItemNotFound)
-	}
-	abkLen := C.CFDataGetLength(C.CFDataRef(abk))
-	abkBytes := C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(C.CFDataRef(abk))), C.int(abkLen))
-
-	if !bytes.Equal(binaryKey, abkBytes) {
-		// record created by a different binary, remove and treat as not found
-		_ = deleteKeychainPassword(service, account)
-		return "", newKeychainError(C.errSecItemNotFound)
-	}
-
-	// if we're here, there's an item that was created by this binary. re-read it, with the data
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecReturnAttributes), unsafe.Pointer(C.kCFBooleanFalse))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecReturnData), unsafe.Pointer(C.kCFBooleanTrue))
-
-	var dataResult C.CFTypeRef
-	status = C.SecItemCopyMatching(C.CFDictionaryRef(query), &dataResult)
-	if err := newKeychainError(status); err != nil {
-		return "", fmt.Errorf("reading with data from keychain: %w", err)
-	}
-	defer C.CFRelease(dataResult)
-
-	length := C.CFDataGetLength(C.CFDataRef(dataResult))
-	bytes := C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(C.CFDataRef(dataResult))), C.int(length))
-
-	return string(bytes), nil
-}
-
-//nolint:govet // the possible unsafe use is fine here
-func deleteKeychainPassword(service, account string) error {
-	serviceRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(service), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(serviceRef))
-	accountRef := C.CFStringCreateWithCString(C.kCFAllocatorDefault, C.CString(account), C.kCFStringEncodingUTF8)
-	defer C.CFRelease(C.CFTypeRef(accountRef))
-
-	query := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
-	defer C.CFRelease(C.CFTypeRef(query))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassGenericPassword))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrService), unsafe.Pointer(serviceRef))
-	C.CFDictionarySetValue(query, unsafe.Pointer(C.kSecAttrAccount), unsafe.Pointer(accountRef))
-
-	return newKeychainError(C.SecItemDelete(C.CFDictionaryRef(query)))
-}
-
-func cfStringToString(cfString C.CFStringRef) string {
-	cStr := C.CFStringGetCStringPtr(cfString, C.kCFStringEncodingUTF8)
-	if cStr != nil {
-		return C.GoString(cStr)
-	}
-
-	length := C.CFStringGetLength(cfString)
-	maxSize := C.CFStringGetMaximumSizeForEncoding(length, C.kCFStringEncodingUTF8)
-	buffer := make([]C.char, maxSize)
-	if result := C.CFStringGetCString(cfString, (*C.char)(unsafe.Pointer(&buffer[0])), maxSize, C.kCFStringEncodingUTF8); result == C.true {
-		return C.GoString(&buffer[0])
-	}
-
-	return ""
+	return "clitoken." + filepath.Base(execPath), nil
 }

--- a/internal/keychain/binary_identity.go
+++ b/internal/keychain/binary_identity.go
@@ -1,0 +1,183 @@
+//go:build darwin && cgo
+
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+*/
+import "C"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"unsafe"
+)
+
+var preferredCDHashes = []CodeSignatureHash{
+	CodeSignatureHashSHA256,
+	CodeSignatureHashSHA256Truncated,
+	CodeSignatureHashSHA384,
+	CodeSignatureHashSHA512,
+	CodeSignatureHashSHA1,
+}
+
+// GetBinaryIdentity returns a unique identifier for the current binary. This
+// can be used to key items for use by this app only, ignoring them silently if
+// the binary changes. This is useful in ad-hoc/temporary items, to avoid
+// prompting the user to unlock the keychain when reading a secret. By default
+// on ARM platforms all binaries must be codesigned, which may be an ad-hoc or
+// formal signature. If the binary is signed, this will return the code signing
+// hash. If the binary is unsigned, this will return the SHA-256 hash of the
+// executable file.
+func GetBinaryIdentity() (string, error) {
+	// TODO - handle legit code-signed binaries, and use something consistent
+	// across versions of them.
+
+	// First, try the preferred method: getting the OS-level CDHash.
+	cdHashes, err := GetSelfCDHashes()
+	if err == nil {
+		for _, hash := range preferredCDHashes {
+			if cdHash, ok := cdHashes[hash]; ok {
+				return cdHash, nil
+			}
+		}
+		return "", fmt.Errorf("no preferred CDHash found")
+	}
+
+	var kErr *Error
+	if errors.As(err, &kErr) && kErr.Code == C.errSecCSUnsigned {
+		return hashExecutableFile()
+	}
+
+	return "", fmt.Errorf("failed to get executable identity: %w", err)
+}
+
+// hashExecutableFile calculates the SHA-256 hash of the current executable file.
+func hashExecutableFile() (string, error) {
+	fmt.Println("Using identifier: SHA-256 Hash (fallback)")
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("os.Executable: %w", err)
+	}
+
+	f, err := os.Open(execPath)
+	if err != nil {
+		return "", fmt.Errorf("os.Open: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("io.Copy: %w", err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+type CodeSignatureHash string
+
+const (
+	CodeSignatureHashSHA1            CodeSignatureHash = "sha1"
+	CodeSignatureHashSHA256          CodeSignatureHash = "sha256"
+	CodeSignatureHashSHA256Truncated CodeSignatureHash = "sha256_truncated"
+	CodeSignatureHashSHA384          CodeSignatureHash = "sha384"
+	CodeSignatureHashSHA512          CodeSignatureHash = "sha512"
+)
+
+// GetSelfCDHashes retrieves a map of all Code Directory Hashes (CDHashes) for
+// the running binary, keyed by their digest algorithm type.
+func GetSelfCDHashes() (map[CodeSignatureHash]string, error) {
+	// Get a reference to the static code of the currently running process.
+	var myselfCode C.SecCodeRef
+	status := C.SecCodeCopySelf(C.kSecCSDefaultFlags, &myselfCode)
+	if status != C.errSecSuccess {
+		return nil, fmt.Errorf("failed to get SecCodeRef for self (error code: %d)", status)
+	}
+	defer C.CFRelease(C.CFTypeRef(myselfCode))
+
+	// Get the code signing information dictionary.
+	var signingInfo C.CFDictionaryRef
+	status = C.SecCodeCopySigningInformation(C.SecStaticCodeRef(myselfCode), C.kSecCSDefaultFlags, &signingInfo)
+	if status != C.errSecSuccess {
+		return nil, fmt.Errorf("failed to copy signing information (error code: %d)", status)
+	}
+	defer C.CFRelease(C.CFTypeRef(signingInfo))
+
+	signingInfoMap := mapFromCFDictionary(signingInfo)
+
+	hashesPtr, hashesOk := signingInfoMap[C.CFTypeRef(C.kSecCodeInfoCdHashes)]
+	algsPtr, algsOk := signingInfoMap[C.CFTypeRef(C.kSecCodeInfoDigestAlgorithms)]
+
+	if !hashesOk || !algsOk {
+		return nil, fmt.Errorf("kSecCodeInfoCdHashes or kSecCodeInfoDigestAlgorithms key not found")
+	}
+
+	if C.CFGetTypeID(C.CFTypeRef(hashesPtr)) != C.CFArrayGetTypeID() || C.CFGetTypeID(C.CFTypeRef(algsPtr)) != C.CFArrayGetTypeID() {
+		return nil, fmt.Errorf("hashes or algorithms value is not a CFArray")
+	}
+
+	hashesArray := C.CFArrayRef(hashesPtr)
+	algsArray := C.CFArrayRef(algsPtr)
+
+	hashesSlice := goSliceFromCFArray(hashesArray)
+	algsSlice := goSliceFromCFArray(algsArray)
+
+	if len(hashesSlice) != len(algsSlice) {
+		return nil, fmt.Errorf("hashes and algorithms arrays have different lengths")
+	}
+	if len(hashesSlice) < 1 {
+		return nil, fmt.Errorf("no hashes found in signing information")
+	}
+
+	resultMap := make(map[CodeSignatureHash]string)
+	for i := range hashesSlice {
+		algPtr := algsSlice[i]
+		if C.CFGetTypeID(C.CFTypeRef(algPtr)) != C.CFNumberGetTypeID() {
+			continue // Skip if not a number
+		}
+		var algID C.int
+		C.CFNumberGetValue(C.CFNumberRef(algPtr), C.kCFNumberIntType, unsafe.Pointer(&algID))
+
+		hashPtr := hashesSlice[i]
+		if C.CFGetTypeID(C.CFTypeRef(hashPtr)) != C.CFDataGetTypeID() {
+			continue // Skip if not data
+		}
+		hashData := C.CFDataRef(hashPtr)
+
+		hashBytes := bytesFromCFData(hashData)
+		if len(hashBytes) > 0 {
+			algName, err := mapAlgorithmIDToString(algID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to map algorithm ID to string: %w", err)
+			}
+			resultMap[algName] = hex.EncodeToString(hashBytes)
+		}
+	}
+
+	return resultMap, nil
+}
+
+// mapAlgorithmIDToString converts a macOS digest algorithm constant to a string.
+func mapAlgorithmIDToString(algID C.int) (CodeSignatureHash, error) {
+	switch algID {
+	case C.kSecCodeSignatureHashSHA1:
+		return CodeSignatureHashSHA1, nil
+	case C.kSecCodeSignatureHashSHA256:
+		return CodeSignatureHashSHA256, nil
+	case C.kSecCodeSignatureHashSHA256Truncated:
+		return CodeSignatureHashSHA256Truncated, nil
+	case C.kSecCodeSignatureHashSHA384:
+		return CodeSignatureHashSHA384, nil
+	case C.kSecCodeSignatureHashSHA512:
+		return CodeSignatureHashSHA512, nil
+	default:
+		return "", fmt.Errorf("unknown code signature hash algorithm: %d", algID)
+	}
+}

--- a/internal/keychain/binary_identity_test.go
+++ b/internal/keychain/binary_identity_test.go
@@ -1,0 +1,29 @@
+//go:build darwin && cgo
+
+package keychain
+
+import "testing"
+
+func TestGetSelfCDHashes(t *testing.T) {
+	hash, err := GetSelfCDHashes()
+	if err != nil {
+		t.Fatalf("GetSelfCDHash failed: %v", err)
+	}
+	t.Logf("CDHashes: %#v", hash)
+}
+
+func TestGetBinaryIdentity(t *testing.T) {
+	hash, err := GetBinaryIdentity()
+	if err != nil {
+		t.Fatalf("GetBinaryIdentity failed: %v", err)
+	}
+	t.Logf("BinaryIdentity: %s", hash)
+}
+
+func TestHashExecutableFile(t *testing.T) {
+	hash, err := hashExecutableFile()
+	if err != nil {
+		t.Fatalf("hashExecutableFile failed: %v", err)
+	}
+	t.Logf("hashExecutableFile: %s", hash)
+}

--- a/internal/keychain/doc.go
+++ b/internal/keychain/doc.go
@@ -1,0 +1,2 @@
+// Package keychain provides a Go wrapper for the macOS keychain.
+package keychain

--- a/internal/keychain/errors.go
+++ b/internal/keychain/errors.go
@@ -1,0 +1,44 @@
+//go:build darwin && cgo
+
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import "fmt"
+
+type ErrorCode int
+
+const (
+	KeychainErrorCodeSuccess       ErrorCode = C.errSecSuccess
+	KeychainErrorCodeDuplicateItem ErrorCode = C.errSecDuplicateItem
+	KeychainErrorCodeUnknown       ErrorCode = 1 // TODO - what's a good
+
+	KeychainErrorCodeItemNotFound ErrorCode = C.errSecItemNotFound
+)
+
+type Error struct {
+	Code ErrorCode
+}
+
+func (e *Error) Error() string {
+	cfError := C.SecCopyErrorMessageString(C.OSStatus(e.Code), nil)
+	if cfError != nilCFStringRef {
+		defer C.CFRelease(C.CFTypeRef(cfError))
+		return fmt.Sprintf("%s (%d)", stringFromCFString(cfError), e.Code)
+	}
+	return fmt.Sprintf("Unknown keychain error: %d", e.Code)
+}
+
+func newKeychainError(status C.OSStatus) error {
+	if status == C.errSecSuccess {
+		return nil
+	}
+	return &Error{
+		Code: ErrorCode(status),
+	}
+}

--- a/internal/keychain/generic_password.go
+++ b/internal/keychain/generic_password.go
@@ -1,0 +1,225 @@
+//go:build darwin && cgo
+
+package keychain
+
+import (
+	"fmt"
+	"maps"
+)
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+
+// GenericPassword are the values for creating or updating a generic
+// password keychain entry.
+//
+// https://developer.apple.com/documentation/security/ksecclassgenericpassword?language=objc
+type GenericPassword struct {
+	// Account name of this item. This is part of the primary key.
+	//
+	// https://developer.apple.com/documentation/security/ksecattraccount?language=objc
+	Account string
+	// Service name of this item. This is part of the primary key.
+	//
+	// https://developer.apple.com/documentation/security/ksecattrservice?language=objc
+	Service string
+	// Label is the user facing label of this item.
+	//
+	// https://developer.apple.com/documentation/security/ksecattrlabel?language=objc
+	Label string
+	// Value is the password to store in the keychain. This is only used on
+	// creation, it will not be returned on list or lookups.
+	//
+	// https://developer.apple.com/documentation/security/ksecvaluedata?language=objc
+	Value []byte
+	// GenericAttributes are the items user-defined attributes.
+	//
+	// https://developer.apple.com/documentation/security/ksecattrgeneric?language=objc
+	GenericAttributes []byte
+}
+
+func (g *GenericPassword) toAttributes() C.CFDictionaryRef {
+	attrs := map[C.CFTypeRef]C.CFTypeRef{
+		C.CFTypeRef(C.kSecClass): C.CFTypeRef(C.kSecClassGenericPassword),
+	}
+
+	// TODO - determine what is required or not, and return a proper error
+
+	if g.Account != "" {
+		accountRef := stringToCFString(g.Account)
+		defer C.CFRelease(C.CFTypeRef(accountRef))
+		attrs[C.CFTypeRef(C.kSecAttrAccount)] = C.CFTypeRef(accountRef)
+	}
+	if g.Service != "" {
+		serviceRef := stringToCFString(g.Service)
+		defer C.CFRelease(C.CFTypeRef(serviceRef))
+		attrs[C.CFTypeRef(C.kSecAttrService)] = C.CFTypeRef(serviceRef)
+	}
+	if g.Label != "" {
+		labelRef := stringToCFString(g.Label)
+		defer C.CFRelease(C.CFTypeRef(labelRef))
+		attrs[C.CFTypeRef(C.kSecAttrLabel)] = C.CFTypeRef(labelRef)
+	}
+	if len(g.GenericAttributes) > 0 {
+		attrs[C.CFTypeRef(C.kSecAttrGeneric)] = C.CFTypeRef(bytesToCFData(g.GenericAttributes))
+	}
+	if len(g.Value) > 0 {
+		attrs[C.CFTypeRef(C.kSecValueData)] = C.CFTypeRef(bytesToCFData(g.Value))
+	}
+
+	return mapToCFDictionary(attrs)
+}
+
+func newGenericPasswordFromResult(result map[C.CFTypeRef]C.CFTypeRef) (GenericPassword, error) {
+	gpa := GenericPassword{}
+	if account, ok := result[C.CFTypeRef(C.kSecAttrAccount)]; ok {
+		gpa.Account = stringFromCFString(C.CFStringRef(account))
+	}
+	if service, ok := result[C.CFTypeRef(C.kSecAttrService)]; ok {
+		gpa.Service = stringFromCFString(C.CFStringRef(service))
+	}
+	if label, ok := result[C.CFTypeRef(C.kSecAttrLabel)]; ok {
+		gpa.Label = stringFromCFString(C.CFStringRef(label))
+	}
+	if generic, ok := result[C.CFTypeRef(C.kSecAttrGeneric)]; ok {
+		gpa.GenericAttributes = bytesFromCFData(C.CFDataRef(generic))
+	}
+	if value, ok := result[C.CFTypeRef(C.kSecValueData)]; ok {
+		gpa.Value = bytesFromCFData(C.CFDataRef(value))
+	}
+
+	return gpa, nil
+}
+
+func CreateGenericPassword(args GenericPassword) error {
+	attrs := args.toAttributes()
+	defer C.CFRelease(C.CFTypeRef(attrs))
+
+	status := C.SecItemAdd(C.CFDictionaryRef(attrs), nil)
+	if err := newKeychainError(status); err != nil {
+		return fmt.Errorf("creating generic password: %w", err)
+	}
+
+	return nil
+}
+
+type GenericPasswordQuery struct {
+	// Account name of this item. This is part of the primary key.
+	//
+	// https://developer.apple.com/documentation/security/ksecattraccount?language=objc
+	Account string
+	// Service name of this item. This is part of the primary key.
+	//
+	// https://developer.apple.com/documentation/security/ksecattrservice?language=objc
+	Service string
+}
+
+func (g *GenericPasswordQuery) toQueryMap(addlAttrs map[C.CFTypeRef]C.CFTypeRef) C.CFDictionaryRef {
+	query := map[C.CFTypeRef]C.CFTypeRef{
+		C.CFTypeRef(C.kSecClass): C.CFTypeRef(C.kSecClassGenericPassword),
+	}
+
+	if g.Account != "" {
+		accountRef := stringToCFString(g.Account)
+		defer C.CFRelease(C.CFTypeRef(accountRef))
+		query[C.CFTypeRef(C.kSecAttrAccount)] = C.CFTypeRef(accountRef)
+	}
+
+	if g.Service != "" {
+		serviceRef := stringToCFString(g.Service)
+		defer C.CFRelease(C.CFTypeRef(serviceRef))
+		query[C.CFTypeRef(C.kSecAttrService)] = C.CFTypeRef(serviceRef)
+	}
+
+	maps.Copy(query, addlAttrs)
+
+	return mapToCFDictionary(query)
+}
+
+func GetGenericPasswordAttributes(query GenericPasswordQuery) (GenericPassword, error) {
+	q := query.toQueryMap(map[C.CFTypeRef]C.CFTypeRef{
+		C.CFTypeRef(C.kSecReturnAttributes): C.CFTypeRef(C.kCFBooleanTrue),
+		C.CFTypeRef(C.kSecMatchLimit):       C.CFTypeRef(C.kSecMatchLimitOne),
+	})
+	defer C.CFRelease(C.CFTypeRef(q))
+
+	var r C.CFTypeRef
+	status := C.SecItemCopyMatching(q, &r)
+	if err := newKeychainError(status); err != nil {
+		return GenericPassword{}, fmt.Errorf("getting generic password attributes: %w", err)
+	}
+	defer C.CFRelease(C.CFTypeRef(r))
+
+	result := mapFromCFDictionary(C.CFDictionaryRef(r))
+
+	return newGenericPasswordFromResult(result)
+}
+
+func GetGenericPassword(query GenericPasswordQuery) ([]byte, error) {
+	q := query.toQueryMap(map[C.CFTypeRef]C.CFTypeRef{
+		C.CFTypeRef(C.kSecReturnData): C.CFTypeRef(C.kCFBooleanTrue),
+		C.CFTypeRef(C.kSecMatchLimit): C.CFTypeRef(C.kSecMatchLimitOne),
+	})
+	defer C.CFRelease(C.CFTypeRef(q))
+
+	var r C.CFTypeRef
+	status := C.SecItemCopyMatching(q, &r)
+	if err := newKeychainError(status); err != nil {
+		return nil, fmt.Errorf("getting generic password attributes: %w", err)
+	}
+	defer C.CFRelease(C.CFTypeRef(r))
+
+	return bytesFromCFData(C.CFDataRef(r)), nil
+}
+
+func ListGenericPasswords(query GenericPasswordQuery) ([]GenericPassword, error) {
+	q := query.toQueryMap(map[C.CFTypeRef]C.CFTypeRef{
+		C.CFTypeRef(C.kSecReturnAttributes): C.CFTypeRef(C.kCFBooleanTrue),
+		C.CFTypeRef(C.kSecMatchLimit):       C.CFTypeRef(C.kSecMatchLimitAll),
+	})
+	defer C.CFRelease(C.CFTypeRef(q))
+
+	var r C.CFTypeRef
+	status := C.SecItemCopyMatching(q, &r)
+	if err := newKeychainError(status); err != nil {
+		return nil, fmt.Errorf("listing generic passwords: %w", err)
+	}
+	defer C.CFRelease(C.CFTypeRef(r))
+
+	result := goSliceFromCFArray(C.CFArrayRef(r))
+
+	passwords := make([]GenericPassword, len(result))
+	for i, r := range result {
+		var err error
+		passwords[i], err = newGenericPasswordFromResult(mapFromCFDictionary(C.CFDictionaryRef(r)))
+		if err != nil {
+			return nil, fmt.Errorf("listing generic passwords: %w", err)
+		}
+	}
+
+	return passwords, nil
+}
+
+// DeleteGenericPassword deletes all items from the keychain that match the
+// query.
+func DeleteGenericPassword(query GenericPasswordQuery) error {
+	if query.Service == "" && query.Account == "" {
+		return fmt.Errorf("cannot delete generic password without service or account")
+	}
+
+	q := query.toQueryMap(map[C.CFTypeRef]C.CFTypeRef{
+		C.CFTypeRef(C.kSecMatchLimit): C.CFTypeRef(C.kSecMatchLimitAll),
+	})
+	defer C.CFRelease(C.CFTypeRef(q))
+
+	status := C.SecItemDelete(C.CFDictionaryRef(q))
+	if err := newKeychainError(status); err != nil {
+		return fmt.Errorf("deleting generic password: %w", err)
+	}
+
+	return nil
+}

--- a/internal/keychain/generic_password_test.go
+++ b/internal/keychain/generic_password_test.go
@@ -1,0 +1,118 @@
+//go:build darwin && cgo
+
+package keychain
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+)
+
+const testService = "li.lds.oauth2ext.keychain.test"
+
+func TestKeychainE2E(t *testing.T) {
+	if os.Getenv("TEST_KEYCHAIN") != "1" {
+		t.Skip("TEST_KEYCHAIN is not set")
+	}
+
+	account := "test"
+
+	// clean up any existing items. Run this before to ensure a clean slate, and
+	// after to not leave stuff lying around.
+	cleanup := func() {
+		if err := DeleteGenericPassword(GenericPasswordQuery{
+			Service: testService,
+		}); err != nil {
+			var kcErr *Error
+			if !errors.As(err, &kcErr) || kcErr.Code != KeychainErrorCodeItemNotFound {
+				t.Fatalf("deleteKeychainPassword failed: %v", err)
+			}
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	password := []byte("test")
+
+	createArgs := GenericPassword{
+		Account: account,
+		Service: testService,
+		Label:   "test-label",
+		Value:   password,
+	}
+
+	if err := CreateGenericPassword(createArgs); err != nil {
+		t.Fatalf("CreateGenericPassword failed: %v", err)
+	}
+
+	attrs, err := GetGenericPasswordAttributes(GenericPasswordQuery{
+		Account: account,
+		Service: testService,
+	})
+	if err != nil {
+		t.Fatalf("GetGenericPasswordAttributes failed: %v", err)
+	}
+
+	if attrs.Account != account {
+		t.Fatalf("account mismatch: want %s, got %s", account, attrs.Account)
+	}
+	if attrs.Service != testService {
+		t.Fatalf("service mismatch: want %s, got %s", testService, attrs.Service)
+	}
+	if len(attrs.Value) > 0 {
+		t.Fatalf("value should be empty, got %s", attrs.Value)
+	}
+
+	gotPassword, err := GetGenericPassword(GenericPasswordQuery{
+		Account: account,
+		Service: testService,
+	})
+	if err != nil {
+		t.Fatalf("getKeychainPassword failed: %v", err)
+	}
+
+	if !bytes.Equal(password, gotPassword) {
+		t.Fatalf("password mismatch: want %s, got %s", string(password), string(gotPassword))
+	}
+
+	// re-try, to ensure it fails how we'd expect
+	if err := CreateGenericPassword(createArgs); err != nil {
+		var kcErr *Error
+		if !errors.As(err, &kcErr) || kcErr.Code != KeychainErrorCodeDuplicateItem {
+			t.Fatalf("CreateGenericPassword should have failed with duplicate item: %v", err)
+		}
+	}
+
+	// Create a second one, to verify list works.
+	if err := CreateGenericPassword(GenericPassword{
+		Account: "second-account",
+		Service: testService,
+		Value:   []byte("second-password"),
+	}); err != nil {
+		var kcErr *Error
+		if !errors.As(err, &kcErr) || kcErr.Code != KeychainErrorCodeDuplicateItem {
+			t.Fatalf("CreateGenericPassword should have failed with duplicate item: %v", err)
+		}
+	}
+
+	list, err := ListGenericPasswords(GenericPasswordQuery{
+		Service: testService,
+	})
+	if err != nil {
+		t.Fatalf("ListGenericPasswords failed: %v", err)
+	}
+
+	t.Logf("list: %#v", list)
+
+	if len(list) != 2 {
+		t.Fatalf("ListGenericPasswords should have returned 1 item, got %d", len(list))
+	}
+
+	if err := DeleteGenericPassword(GenericPasswordQuery{
+		Account: account,
+		Service: testService,
+	}); err != nil {
+		t.Fatalf("deleteKeychainPassword failed: %v", err)
+	}
+}

--- a/internal/keychain/types.go
+++ b/internal/keychain/types.go
@@ -1,0 +1,239 @@
+//go:build darwin && cgo
+
+package keychain
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <stdlib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+import "unsafe"
+
+var (
+	nilCFStringRef C.CFStringRef
+	nilCFDataRef   C.CFDataRef
+)
+
+// stringToCFString creates a new CFStringRef from a Go string.
+// It properly handles the allocation and freeing of the intermediate C string.
+// The caller is responsible for calling C.CFRelease on the returned CFStringRef.
+func stringToCFString(s string) C.CFStringRef {
+	cString := C.CString(s)
+	defer C.free(unsafe.Pointer(cString))
+	return C.CFStringCreateWithCString(C.kCFAllocatorDefault, cString, C.kCFStringEncodingUTF8)
+}
+
+// stringFromCFString converts a CFStringRef into a new Go string.
+func stringFromCFString(cfString C.CFStringRef) string {
+	if cfString == nilCFStringRef {
+		return ""
+	}
+	// Fast path: try to get a direct pointer to the C string.
+	// This is a "borrowed" pointer, so we don't free it.
+	cStr := C.CFStringGetCStringPtr(cfString, C.kCFStringEncodingUTF8)
+	if cStr != nil {
+		return C.GoString(cStr)
+	}
+
+	// Slow path: if a direct pointer is not available, we must copy the bytes.
+	length := C.CFStringGetLength(cfString)
+	if length == 0 {
+		return ""
+	}
+	maxSize := C.CFStringGetMaximumSizeForEncoding(length, C.kCFStringEncodingUTF8)
+
+	// Allocate a buffer on the C heap, which is safer than using a Go slice.
+	buffer := C.malloc(C.size_t(maxSize))
+	defer C.free(buffer)
+
+	if C.CFStringGetCString(cfString, (*C.char)(buffer), maxSize, C.kCFStringEncodingUTF8) == C.true {
+		return C.GoString((*C.char)(buffer))
+	}
+
+	return ""
+}
+
+// mapToCFDictionary creates a new CFDictionaryRef from a Go map using unsafe.Slice.
+// It safely allocates temporary C arrays for the keys and values.
+// The caller is responsible for calling C.CFRelease on the returned dictionary.
+func mapToCFDictionary(m map[C.CFTypeRef]C.CFTypeRef) C.CFDictionaryRef {
+	count := len(m)
+
+	// Handle the edge case of an empty map.
+	if count == 0 {
+		return C.CFDictionaryCreate(C.kCFAllocatorDefault, nil, nil, 0,
+			&C.kCFTypeDictionaryKeyCallBacks,
+			&C.kCFTypeDictionaryValueCallBacks)
+	}
+
+	keysPtr := C.malloc(C.size_t(count) * C.size_t(unsafe.Sizeof(unsafe.Pointer(nil))))
+	defer C.free(keysPtr)
+
+	valsPtr := C.malloc(C.size_t(count) * C.size_t(unsafe.Sizeof(unsafe.Pointer(nil))))
+	defer C.free(valsPtr)
+
+	keysSlice := unsafe.Slice((*unsafe.Pointer)(keysPtr), count)
+	valsSlice := unsafe.Slice((*unsafe.Pointer)(valsPtr), count)
+
+	i := 0
+	for k, v := range m {
+		keysSlice[i] = unsafe.Pointer(k) //nolint:govet // C memory to C memory
+		valsSlice[i] = unsafe.Pointer(v) //nolint:govet // C memory to C memory
+		i++
+	}
+
+	ref := C.CFDictionaryCreate(C.kCFAllocatorDefault,
+		(*unsafe.Pointer)(keysPtr), // Pointer to the C array of keys
+		(*unsafe.Pointer)(valsPtr), // Pointer to the C array of values
+		C.CFIndex(count),
+		&C.kCFTypeDictionaryKeyCallBacks,
+		&C.kCFTypeDictionaryValueCallBacks)
+
+	return ref
+}
+
+// mapFromCFDictionary converts a CFDictionaryRef into a Go map.
+//
+// The keys and values in the returned map are C.CFTypeRef. The caller is
+// responsible for converting them to more specific types (e.g., CFStringRef
+// to a Go string) if needed.
+//
+// IMPORTANT: The pointers in the returned map are "borrowed references" from
+// the input dictionary. Their validity is tied to the lifetime of the input
+// `dict`. You DO NOT own them and MUST NOT call C.CFRelease on them.
+func mapFromCFDictionary(dict C.CFDictionaryRef) map[C.CFTypeRef]C.CFTypeRef {
+	count := C.CFDictionaryGetCount(dict)
+	if count == 0 {
+		return make(map[C.CFTypeRef]C.CFTypeRef)
+	}
+
+	// Allocate memory on the C heap to store the keys and values. The size is
+	// the number of items multiplied by the size of a pointer.
+	keysPtr := C.malloc(C.size_t(count) * C.size_t(unsafe.Sizeof(unsafe.Pointer(nil))))
+	defer C.free(keysPtr)
+
+	valsPtr := C.malloc(C.size_t(count) * C.size_t(unsafe.Sizeof(unsafe.Pointer(nil))))
+	defer C.free(valsPtr)
+
+	// populate our C arrays with pointers from the dictionary.
+	C.CFDictionaryGetKeysAndValues(dict,
+		(*unsafe.Pointer)(keysPtr),
+		(*unsafe.Pointer)(valsPtr),
+	)
+
+	keysSlice := unsafe.Slice((*unsafe.Pointer)(keysPtr), count)
+	valsSlice := unsafe.Slice((*unsafe.Pointer)(valsPtr), count)
+
+	goMap := make(map[C.CFTypeRef]C.CFTypeRef, count)
+	for i := 0; i < int(count); i++ {
+		key := C.CFTypeRef(keysSlice[i])
+		value := C.CFTypeRef(valsSlice[i])
+		goMap[key] = value
+	}
+
+	return goMap
+}
+
+// bytesToCFData creates a new CFDataRef from a Go byte slice.
+// It properly handles the allocation and freeing of the intermediate C buffer.
+// The caller is responsible for calling C.CFRelease on the returned CFDataRef.
+func bytesToCFData(data []byte) C.CFDataRef {
+	if len(data) == 0 {
+		// CFDataCreate with a NULL pointer and 0 length is the correct way
+		// to create an empty CFData object.
+		return C.CFDataCreate(C.kCFAllocatorDefault, nil, 0)
+	}
+
+	cBytes := C.CBytes(data)
+	defer C.free(cBytes)
+
+	// CFDataCreate copies the data from our temporary C buffer, so we can free
+	// the buffer immediately after the call.
+	return C.CFDataCreate(C.kCFAllocatorDefault, (*C.UInt8)(cBytes), C.CFIndex(len(data)))
+}
+
+// bytesFromCFData converts a CFDataRef into a new Go byte slice.
+// It creates a copy of the data from the CFData object.
+func bytesFromCFData(data C.CFDataRef) []byte {
+	if data == nilCFDataRef {
+		return nil
+	}
+	length := C.CFDataGetLength(data)
+	if length == 0 {
+		return []byte{}
+	}
+
+	// Try to get a direct pointer to the data's internal buffer.
+	// This is the most efficient path.
+	ptr := C.CFDataGetBytePtr(data)
+
+	if ptr != nil {
+		// C.GoBytes creates a new Go slice and copies the C data into it.
+		// This is the preferred and safest way to copy the data.
+		return C.GoBytes(unsafe.Pointer(ptr), C.int(length))
+	}
+
+	// If a direct pointer is not available (e.g., the data is stored
+	// non-contiguously), we must copy the bytes manually.
+	bytes := make([]byte, length)
+	byteRange := C.CFRange{location: 0, length: length}
+	C.CFDataGetBytes(data, byteRange, (*C.UInt8)(&bytes[0]))
+	return bytes
+}
+
+// sliceToCFArray creates a new CFArrayRef from a Go slice of CFTypeRef. It safely
+// allocates a temporary C array for the values. The caller is responsible for
+// calling C.CFRelease on the returned CFArrayRef.
+func sliceToCFArray(slice []C.CFTypeRef) C.CFArrayRef {
+	count := len(slice)
+	if count == 0 {
+		return C.CFArrayCreate(C.kCFAllocatorDefault, nil, 0, &C.kCFTypeArrayCallBacks)
+	}
+
+	valsPtr := C.malloc(C.size_t(count) * C.size_t(unsafe.Sizeof(unsafe.Pointer(nil))))
+	defer C.free(valsPtr)
+
+	valsSlice := unsafe.Slice((*unsafe.Pointer)(valsPtr), count)
+
+	for i, v := range slice {
+		valsSlice[i] = unsafe.Pointer(v) //nolint:govet // C memory to C memory
+	}
+
+	// 4. Call the C function, passing a pointer to the C-managed array.
+	ref := C.CFArrayCreate(C.kCFAllocatorDefault,
+		(*unsafe.Pointer)(valsPtr),
+		C.CFIndex(count),
+		&C.kCFTypeArrayCallBacks)
+
+	return ref
+}
+
+// goSliceFromCFArray converts a CFArrayRef into a new Go slice of CFTypeRef.
+//
+// IMPORTANT: The pointers in the returned slice are "borrowed references" from
+// the input array. Their validity is tied to the lifetime of the input `array`.
+// You DO NOT own them and MUST NOT call C.CFRelease on them.
+func goSliceFromCFArray(array C.CFArrayRef) []C.CFTypeRef {
+	count := C.CFArrayGetCount(array)
+	if count == 0 {
+		return []C.CFTypeRef{}
+	}
+
+	valsPtr := C.malloc(C.size_t(count) * C.size_t(unsafe.Sizeof(unsafe.Pointer(nil))))
+	defer C.free(valsPtr)
+
+	valueRange := C.CFRange{location: 0, length: count}
+	C.CFArrayGetValues(array, valueRange, (*unsafe.Pointer)(valsPtr))
+
+	valsSlice := unsafe.Slice((*unsafe.Pointer)(valsPtr), count)
+
+	goSlice := make([]C.CFTypeRef, count)
+	for i, v := range valsSlice {
+		goSlice[i] = C.CFTypeRef(v)
+	}
+
+	return goSlice
+}


### PR DESCRIPTION
I've written small parts of the keychain code a bunch of times now. It's probably time to extract a module for this, so move the keychain code in to it's own package as a precursor. Update it with some Core Foundation helpers to make it play nice with Go types, so the higher level code can be more Go like. Extend it with better list/delete functionality. The end result is a more generic package to interact with keychain generic passwords, that we can turn in to a module later.

The previous method we used to determine a unique binary was it's name and creation time. This is OK, but doesn't handle copies, nor aligns with what Keychain uses to determine what the binary is. All binaries on ARM Macs need to be code-signed, even if it is an ad-hoc signature. Add a function to fetch the code signature information, which is more aligned with how keychain judges a binary. We can use this to track what code created an item. AMD64 doesn't have this requirement, so add a fallback which is a SHA256 of the running binary.

Update the clitoken credential cache to use this new code. Make the service name an optional item when setting this up, and add methods to list and delete credentials. If that becomes useful, we can update the other implementations to do the same.