### PR TITLE
jwt: Bring back claims Extra

### DIFF
--- a/jwt/at_verifier.go
+++ b/jwt/at_verifier.go
@@ -22,8 +22,9 @@ func (a *AccessTokenVerifier) Verify(ctx context.Context, token *oauth2.Token) (
 
 func (a *AccessTokenVerifier) VerifyRaw(ctx context.Context, rawJWT string) (*AccessTokenClaims, error) {
 	vopts := verifyOpts{
-		Issuer:          a.Provider.Issuer(),
-		SupportedAlgs:   algsToJOSEAlgs(a.Provider.SupportedAlgs()),
+		Issuer:          a.Provider.GetIssuer(),
+		WantType:        JWTTYPAccessToken,
+		SupportedAlgs:   algsToJOSEAlgs(a.Provider.GetSupportedAlgs()),
 		WantAnyAudience: jwt.Audience(a.WantAnyAudience),
 		SkipAudience:    a.IgnoreAudience,
 		ValidTimeBuffer: defaultValidTimeBuffer,
@@ -38,7 +39,6 @@ func (a *AccessTokenVerifier) VerifyRaw(ctx context.Context, rawJWT string) (*Ac
 	if err := jwt.UnmarshalClaims(&cl); err != nil {
 		return nil, fmt.Errorf("unmarshalling access_token: %w", err)
 	}
-	cl.jwt = jwt
 
 	return &cl, nil
 }
@@ -47,5 +47,5 @@ func (a *AccessTokenVerifier) keyset() PublicKeyset {
 	if a.OverrideKeyset != nil {
 		return a.OverrideKeyset
 	}
-	return a.Provider.Keyset()
+	return a.Provider.GetKeyset()
 }

--- a/jwt/at_verifier_test.go
+++ b/jwt/at_verifier_test.go
@@ -55,7 +55,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 		{
 			name: "valid access token",
 			setupToken: func() (string, error) {
-				return testSigner.Sign(validClaims, "")
+				return testSigner.Sign(validClaims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -104,7 +104,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 		{
 			name: "wrong audience",
 			setupToken: func() (string, error) {
-				return testSigner.Sign(validClaims, "")
+				return testSigner.Sign(validClaims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -124,7 +124,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			setupToken: func() (string, error) {
 				claims := validClaims
 				claims.Audience = StrOrSlice{"wrong-audience"}
-				return testSigner.Sign(claims, "")
+				return testSigner.Sign(claims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -144,7 +144,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			setupToken: func() (string, error) {
 				claims := validClaims
 				claims.Audience = StrOrSlice{"test-audience", "another-audience"}
-				return testSigner.Sign(claims, "")
+				return testSigner.Sign(claims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -163,7 +163,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			setupToken: func() (string, error) {
 				claims := validClaims
 				claims.Issuer = "https://wrong-issuer.com"
-				return testSigner.Sign(claims, "")
+				return testSigner.Sign(claims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -183,7 +183,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			setupToken: func() (string, error) {
 				claims := validClaims
 				claims.Expiry = UnixTime(time.Now().Add(-1 * time.Hour).Unix())
-				return testSigner.Sign(claims, "")
+				return testSigner.Sign(claims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -205,7 +205,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 				// Note: The verification logic doesn't check for future IssuedAt times
 				claims := validClaims
 				claims.IssuedAt = UnixTime(time.Now().Add(1 * time.Hour).Unix()) // Issued in the future
-				return testSigner.Sign(claims, "")
+				return testSigner.Sign(claims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -222,7 +222,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 		{
 			name: "wrong key",
 			setupToken: func() (string, error) {
-				return testSigner.Sign(validClaims, "")
+				return testSigner.Sign(validClaims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -240,7 +240,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 		{
 			name: "override keyset",
 			setupToken: func() (string, error) {
-				return testSigner.Sign(validClaims, "")
+				return testSigner.Sign(validClaims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -282,7 +282,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 					Subject: "test-subject",
 					// Missing Audience, Expiry, IssuedAt, JWTID, ClientID
 				}
-				return testSigner.Sign(incompleteClaims, "")
+				return testSigner.Sign(incompleteClaims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -311,7 +311,7 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 					JWTID:    "test-jti",
 					ClientID: "test-client-id",
 				}
-				return testSigner.Sign(minimalClaims, "")
+				return testSigner.Sign(minimalClaims, JWTTYPAccessToken)
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
@@ -401,7 +401,7 @@ func TestAccessTokenVerifier_Verify(t *testing.T) {
 		{
 			name: "valid token with access_token",
 			setupToken: func() *oauth2.Token {
-				accessToken, err := testSigner.Sign(validClaims, "")
+				accessToken, err := testSigner.Sign(validClaims, JWTTYPAccessToken)
 				if err != nil {
 					t.Fatalf("Failed to sign token: %v", err)
 				}

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -1,0 +1,350 @@
+package jwt
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/lstoll/oauth2ext/internal/th"
+)
+
+func TestClaimsJSONRoundtrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		claims      any
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "IDClaims basic roundtrip",
+			claims: &IDClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"client1"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				Extra: map[string]any{
+					"custom_claim": "custom_value",
+					"nested": map[string]any{
+						"key": "value",
+					},
+				},
+			},
+		},
+		{
+			name: "IDClaims with multiple audiences",
+			claims: &IDClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"client1", "client2"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				Nonce:    "nonce123",
+				ACR:      "urn:mace:incommon:iap:silver",
+				AMR:      []string{"pwd", "otp"},
+				AZP:      "client1",
+				Extra: map[string]any{
+					"preferred_username": "johndoe",
+					"email":              "john@example.com",
+				},
+			},
+		},
+		{
+			name: "AccessTokenClaims basic roundtrip",
+			claims: &AccessTokenClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"api.example.com"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				ClientID: "client1",
+				JWTID:    "jwt123",
+				Scope:    "read write",
+				Extra: map[string]any{
+					"custom_claim": "custom_value",
+				},
+			},
+		},
+		{
+			name: "AccessTokenClaims with groups and roles",
+			claims: &AccessTokenClaims{
+				Issuer:       "https://example.com",
+				Subject:      "user123",
+				Audience:     StrOrSlice([]string{"api.example.com"}),
+				Expiry:       UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt:     UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				ClientID:     "client1",
+				JWTID:        "jwt123",
+				Groups:       []string{"admin", "users"},
+				Roles:        []string{"read", "write"},
+				Entitlements: []string{"feature1", "feature2"},
+				Extra: map[string]any{
+					"preferred_username": "johndoe",
+				},
+			},
+		},
+		{
+			name: "IDClaims with iss conflict in extra",
+			claims: &IDClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"client1"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				Extra: map[string]any{
+					"iss": "conflicting_issuer",
+				},
+			},
+			expectError: true,
+			errorMsg:    "json: error calling MarshalJSON for type *jwt.IDClaims: extra claim \"iss\" conflicts with standard claim",
+		},
+		{
+			name: "IDClaims with sub conflict in extra",
+			claims: &IDClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"client1"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				Extra: map[string]any{
+					"sub": "conflicting_subject",
+				},
+			},
+			expectError: true,
+			errorMsg:    "json: error calling MarshalJSON for type *jwt.IDClaims: extra claim \"sub\" conflicts with standard claim",
+		},
+		{
+			name: "AccessTokenClaims with client_id conflict in extra",
+			claims: &AccessTokenClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"api.example.com"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				ClientID: "client1",
+				JWTID:    "jwt123",
+				Extra: map[string]any{
+					"client_id": "conflicting_client_id",
+				},
+			},
+			expectError: true,
+			errorMsg:    "json: error calling MarshalJSON for type *jwt.AccessTokenClaims: extra claim \"client_id\" conflicts with standard claim",
+		},
+		{
+			name: "AccessTokenClaims with jti conflict in extra",
+			claims: &AccessTokenClaims{
+				Issuer:   "https://example.com",
+				Subject:  "user123",
+				Audience: StrOrSlice([]string{"api.example.com"}),
+				Expiry:   UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-20")).Unix()),
+				IssuedAt: UnixTime(th.Must(time.Parse("2006-Jan-02", "2019-Nov-19")).Unix()),
+				ClientID: "client1",
+				JWTID:    "jwt123",
+				Extra: map[string]any{
+					"jti": "conflicting_jti",
+				},
+			},
+			expectError: true,
+			errorMsg:    "json: error calling MarshalJSON for type *jwt.AccessTokenClaims: extra claim \"jti\" conflicts with standard claim",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Marshal the claims to JSON
+			jsonData, err := json.Marshal(tt.claims)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				if tt.errorMsg != "" && err.Error() != tt.errorMsg {
+					t.Errorf("expected error message %q, got %q", tt.errorMsg, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to marshal claims: %v", err)
+			}
+
+			// Unmarshal back to a new instance
+			var unmarshaledClaims any
+			switch tt.claims.(type) {
+			case *IDClaims:
+				unmarshaledClaims = &IDClaims{}
+			case *AccessTokenClaims:
+				unmarshaledClaims = &AccessTokenClaims{}
+			default:
+				t.Fatal("unknown claims type")
+			}
+
+			if err := json.Unmarshal(jsonData, unmarshaledClaims); err != nil {
+				t.Fatalf("failed to unmarshal claims: %v", err)
+			}
+
+			// Compare the original and unmarshaled claims
+			if diff := cmp.Diff(tt.claims, unmarshaledClaims, cmpopts.IgnoreUnexported(IDClaims{}, AccessTokenClaims{})); diff != "" {
+				t.Errorf("claims roundtrip failed (-want +got):\n%s", diff)
+			}
+
+			// Test UnmarshalClaims method if raw data is available
+			switch claims := tt.claims.(type) {
+			case *IDClaims:
+				if len(claims.raw) > 0 {
+					var dest map[string]any
+					if err := claims.UnmarshalClaims(&dest); err != nil {
+						t.Errorf("UnmarshalClaims failed: %v", err)
+					}
+				}
+			case *AccessTokenClaims:
+				if len(claims.raw) > 0 {
+					var dest map[string]any
+					if err := claims.UnmarshalClaims(&dest); err != nil {
+						t.Errorf("UnmarshalClaims failed: %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestClaimsUnmarshalClaimsError(t *testing.T) {
+	// Test UnmarshalClaims with claims that don't have raw data
+	idClaims := &IDClaims{
+		Issuer:  "https://example.com",
+		Subject: "user123",
+	}
+
+	var dest map[string]any
+	err := idClaims.UnmarshalClaims(&dest)
+	if err == nil {
+		t.Fatal("expected error when calling UnmarshalClaims on claims without raw data")
+	}
+	if err.Error() != "can only unmarshal claims from a JSON created IDClaims" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
+
+	accessClaims := &AccessTokenClaims{
+		Issuer:  "https://example.com",
+		Subject: "user123",
+	}
+
+	err = accessClaims.UnmarshalClaims(&dest)
+	if err == nil {
+		t.Fatal("expected error when calling UnmarshalClaims on claims without raw data")
+	}
+	if err.Error() != "can only unmarshal claims from a JSON created AccessTokenClaims" {
+		t.Errorf("expected specific error message, got: %v", err)
+	}
+}
+
+func TestClaimsJSONParsing(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonData    string
+		claimsType  string
+		expectError bool
+	}{
+		{
+			name: "IDClaims from JSON with extra claims",
+			jsonData: `{
+				"iss": "https://example.com",
+				"sub": "user123",
+				"aud": "client1",
+				"exp": 1574208000,
+				"iat": 1574121600,
+				"custom_claim": "custom_value",
+				"nested_claim": {"key": "value"}
+			}`,
+			claimsType: "IDClaims",
+		},
+		{
+			name: "AccessTokenClaims from JSON with extra claims",
+			jsonData: `{
+				"iss": "https://example.com",
+				"sub": "user123",
+				"aud": "api.example.com",
+				"exp": 1574208000,
+				"iat": 1574121600,
+				"client_id": "client1",
+				"jti": "jwt123",
+				"groups": ["admin", "users"],
+				"roles": ["read", "write"],
+				"custom_claim": "custom_value"
+			}`,
+			claimsType: "AccessTokenClaims",
+		},
+		{
+			name: "IDClaims with single audience string",
+			jsonData: `{
+				"iss": "https://example.com",
+				"sub": "user123",
+				"aud": "client1",
+				"exp": 1574208000,
+				"iat": 1574121600
+			}`,
+			claimsType: "IDClaims",
+		},
+		{
+			name: "IDClaims with multiple audiences array",
+			jsonData: `{
+				"iss": "https://example.com",
+				"sub": "user123",
+				"aud": ["client1", "client2"],
+				"exp": 1574208000,
+				"iat": 1574121600
+			}`,
+			claimsType: "IDClaims",
+		},
+		{
+			name: "Invalid JSON",
+			jsonData: `{
+				"iss": "https://example.com",
+				"sub": "user123",
+				"aud": "client1",
+				"exp": 1574208000,
+				"iat": 1574121600,
+			}`,
+			claimsType:  "IDClaims",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var claims any
+			switch tt.claimsType {
+			case "IDClaims":
+				claims = &IDClaims{}
+			case "AccessTokenClaims":
+				claims = &AccessTokenClaims{}
+			default:
+				t.Fatal("unknown claims type")
+			}
+
+			err := json.Unmarshal([]byte(tt.jsonData), claims)
+			if tt.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to unmarshal JSON: %v", err)
+			}
+
+			// Verify that extra claims were properly parsed
+			switch c := claims.(type) {
+			case *IDClaims:
+				if c.Extra == nil {
+					t.Error("expected Extra map to be populated")
+				}
+			case *AccessTokenClaims:
+				if c.Extra == nil {
+					t.Error("expected Extra map to be populated")
+				}
+			}
+		})
+	}
+}

--- a/jwt/id_verifier.go
+++ b/jwt/id_verifier.go
@@ -28,8 +28,8 @@ func (i *IDTokenVerifier) Verify(ctx context.Context, token *oauth2.Token) (*IDC
 
 func (i *IDTokenVerifier) VerifyRaw(ctx context.Context, rawJWT string) (*IDClaims, error) {
 	vopts := verifyOpts{
-		Issuer:          i.Provider.Issuer(),
-		SupportedAlgs:   algsToJOSEAlgs(i.Provider.SupportedAlgs()),
+		Issuer:          i.Provider.GetIssuer(),
+		SupportedAlgs:   algsToJOSEAlgs(i.Provider.GetSupportedAlgs()),
 		WantAnyAudience: jwt.Audience{i.ClientID},
 		SkipAudience:    i.IgnoreClientID,
 		WantAnyACR:      i.WantAnyACR,
@@ -45,7 +45,6 @@ func (i *IDTokenVerifier) VerifyRaw(ctx context.Context, rawJWT string) (*IDClai
 	if err := jwt.UnmarshalClaims(&cl); err != nil {
 		return nil, fmt.Errorf("unmarshalling id_token: %w", err)
 	}
-	cl.jwt = jwt
 
 	return &cl, nil
 }
@@ -54,5 +53,5 @@ func (i *IDTokenVerifier) keyset() PublicKeyset {
 	if i.OverrideKeyset != nil {
 		return i.OverrideKeyset
 	}
-	return i.Provider.Keyset()
+	return i.Provider.GetKeyset()
 }

--- a/jwt/id_verifier_test.go
+++ b/jwt/id_verifier_test.go
@@ -16,15 +16,15 @@ type mockProvider struct {
 	supportedAlgs []string
 }
 
-func (m *mockProvider) Issuer() string {
+func (m *mockProvider) GetIssuer() string {
 	return m.issuer
 }
 
-func (m *mockProvider) Keyset() PublicKeyset {
+func (m *mockProvider) GetKeyset() PublicKeyset {
 	return m.keyset
 }
 
-func (m *mockProvider) SupportedAlgs() []string {
+func (m *mockProvider) GetSupportedAlgs() []string {
 	return m.supportedAlgs
 }
 

--- a/jwt/provider.go
+++ b/jwt/provider.go
@@ -1,7 +1,7 @@
 package jwt
 
 type Provider interface {
-	Issuer() string
-	Keyset() PublicKeyset
-	SupportedAlgs() []string
+	GetIssuer() string
+	GetKeyset() PublicKeyset
+	GetSupportedAlgs() []string
 }

--- a/oauth2as/server_token.go
+++ b/oauth2as/server_token.go
@@ -469,21 +469,19 @@ func (s *Server) buildTokenResponse(ctx context.Context, alg SigningAlg, grant *
 	if ac == nil {
 		ac = &jwt.AccessTokenClaims{}
 	}
-	// if ac.Extra == nil {
-	// 	ac.Extra = map[string]any{}
-	// }
+	if ac.Extra == nil {
+		ac.Extra = map[string]any{}
+	}
 
 	ac.Issuer = s.config.Issuer
 	ac.Subject = grant.UserID
 	ac.ClientID = grant.ClientID
 	ac.Expiry = jwt.UnixTime(atExp.Unix())
-	ac.Audience = jwt.StrOrSlice{s.config.Issuer}
+	ac.Audience = jwt.StrOrSlice{grant.ClientID}
 	ac.IssuedAt = jwt.UnixTime(s.now().Unix())
 	ac.AuthTime = jwt.UnixTime(grant.GrantedAt.Unix())
 	ac.JWTID = uuid.Must(uuid.NewRandom()).String()
-	// TODO(lstoll) - add this to the claims
-	// ac.Extra[claimGrantID] = grant.ID.String()
-	_ = claimGrantID
+	ac.Extra[claimGrantID] = grant.ID.String()
 
 	if tresp.OverrideAccessTokenSubject != "" {
 		ac.Subject = tresp.OverrideAccessTokenSubject

--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -37,7 +37,8 @@ type Provider struct {
 	// will be used. This will be overridden by the context if provided.
 	HTTPClient *http.Client
 
-	keyset jwt.PublicKeyset
+	// Keyset for verifying tokens issued by this provider.
+	Keyset jwt.PublicKeyset
 }
 
 // DiscoverProvider will discover Provider from the given issuer. The returned
@@ -66,7 +67,7 @@ func DiscoverProvider(ctx context.Context, issuer string) (*Provider, error) {
 		return nil, fmt.Errorf("error decoding provider metadata response: %v", err)
 	}
 
-	p.keyset = &jwt.HTTPJWKSKeyset{
+	p.Keyset = &jwt.HTTPJWKSKeyset{
 		HTTPClient: p.HTTPClient,
 		URL:        p.Metadata.JWKSURI,
 	}
@@ -82,15 +83,15 @@ func (p *Provider) Endpoint() oauth2.Endpoint {
 	}
 }
 
-func (p *Provider) Keyset() jwt.PublicKeyset {
-	return p.keyset
+func (p *Provider) GetKeyset() jwt.PublicKeyset {
+	return p.Keyset
 }
 
-func (p *Provider) SupportedAlgs() []string {
+func (p *Provider) GetSupportedAlgs() []string {
 	return p.Metadata.IDTokenSigningAlgValuesSupported
 }
 
-func (p *Provider) Issuer() string {
+func (p *Provider) GetIssuer() string {
 	return p.Metadata.Issuer
 }
 


### PR DESCRIPTION
This is actually pretty convenient, especially when constructing claims. Bring it back, and keep the unmarshalclaims side of things too. This gives the option of simple cases using extra, and more complicated unmarshaling in to a custom type.