### PR TITLE
oauth2as: Remove discovery

### DIFF
--- a/jwt/at_verifier.go
+++ b/jwt/at_verifier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type AccessTokenVerifier struct {
-	Provider       Provider
+	Provider       Issuer
 	OverrideKeyset PublicKeyset
 
 	WantAnyAudience []string
@@ -22,7 +22,7 @@ func (a *AccessTokenVerifier) Verify(ctx context.Context, token *oauth2.Token) (
 
 func (a *AccessTokenVerifier) VerifyRaw(ctx context.Context, rawJWT string) (*AccessTokenClaims, error) {
 	vopts := verifyOpts{
-		Issuer:          a.Provider.GetIssuer(),
+		Issuer:          a.Provider.GetIssuerURL(),
 		WantType:        JWTTYPAccessToken,
 		SupportedAlgs:   algsToJOSEAlgs(a.Provider.GetSupportedAlgs()),
 		WantAnyAudience: jwt.Audience(a.WantAnyAudience),

--- a/jwt/at_verifier_test.go
+++ b/jwt/at_verifier_test.go
@@ -59,10 +59,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -108,10 +108,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"wrong-audience"},
 				}
@@ -128,10 +128,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 					IgnoreAudience:  true,
@@ -148,10 +148,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"another-audience", "third-audience"},
 				}
@@ -167,10 +167,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -187,10 +187,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -209,10 +209,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -226,10 +226,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        wrongKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        wrongKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -244,10 +244,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        wrongKeyset, // This should be ignored
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        wrongKeyset, // This should be ignored
+						SupportedAlgs: []string{"ES256"},
 					},
 					OverrideKeyset:  validKeyset, // This should be used
 					WantAnyAudience: []string{"test-audience"},
@@ -262,10 +262,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -286,10 +286,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -315,10 +315,10 @@ func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -411,10 +411,10 @@ func TestAccessTokenVerifier_Verify(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -430,10 +430,10 @@ func TestAccessTokenVerifier_Verify(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}
@@ -450,10 +450,10 @@ func TestAccessTokenVerifier_Verify(t *testing.T) {
 			},
 			setupVerifier: func() *AccessTokenVerifier {
 				return &AccessTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					WantAnyAudience: []string{"test-audience"},
 				}

--- a/jwt/id_verifier.go
+++ b/jwt/id_verifier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type IDTokenVerifier struct {
-	Provider       Provider
+	Provider       Issuer
 	OverrideKeyset PublicKeyset
 
 	ClientID       string
@@ -28,7 +28,7 @@ func (i *IDTokenVerifier) Verify(ctx context.Context, token *oauth2.Token) (*IDC
 
 func (i *IDTokenVerifier) VerifyRaw(ctx context.Context, rawJWT string) (*IDClaims, error) {
 	vopts := verifyOpts{
-		Issuer:          i.Provider.GetIssuer(),
+		Issuer:          i.Provider.GetIssuerURL(),
 		SupportedAlgs:   algsToJOSEAlgs(i.Provider.GetSupportedAlgs()),
 		WantAnyAudience: jwt.Audience{i.ClientID},
 		SkipAudience:    i.IgnoreClientID,

--- a/jwt/id_verifier_test.go
+++ b/jwt/id_verifier_test.go
@@ -10,24 +10,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type mockProvider struct {
-	issuer        string
-	keyset        PublicKeyset
-	supportedAlgs []string
-}
-
-func (m *mockProvider) GetIssuer() string {
-	return m.issuer
-}
-
-func (m *mockProvider) GetKeyset() PublicKeyset {
-	return m.keyset
-}
-
-func (m *mockProvider) GetSupportedAlgs() []string {
-	return m.supportedAlgs
-}
-
 func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 	// Create valid ID token claims
 	now := time.Now()
@@ -74,10 +56,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -111,10 +93,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "wrong-client-id",
 				}
@@ -131,10 +113,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID:       "test-client-id",
 					IgnoreClientID: true,
@@ -149,10 +131,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID:   "test-client-id",
 					WantAnyACR: []string{"urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"},
@@ -167,10 +149,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID:   "test-client-id",
 					WantAnyACR: []string{"urn:oasis:names:tc:SAML:2.0:ac:classes:TwoFactorContract"},
@@ -186,10 +168,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 					WantAnyACR: []string{
@@ -209,10 +191,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -229,10 +211,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -249,10 +231,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -267,10 +249,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        wrongKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        wrongKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -285,10 +267,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        wrongKeyset, // This should be ignored
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        wrongKeyset, // This should be ignored
+						SupportedAlgs: []string{"ES256"},
 					},
 					OverrideKeyset: validKeyset, // This should be used
 					ClientID:       "test-client-id",
@@ -303,10 +285,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -327,10 +309,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -349,10 +331,10 @@ func TestIDTokenVerifier_VerifyRaw(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -435,10 +417,10 @@ func TestIDTokenVerifier_Verify(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -454,10 +436,10 @@ func TestIDTokenVerifier_Verify(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}
@@ -474,10 +456,10 @@ func TestIDTokenVerifier_Verify(t *testing.T) {
 			},
 			setupVerifier: func() *IDTokenVerifier {
 				return &IDTokenVerifier{
-					Provider: &mockProvider{
-						issuer:        "https://test-issuer.com",
-						keyset:        validKeyset,
-						supportedAlgs: []string{"ES256"},
+					Provider: &StaticIssuer{
+						IssuerURL:     "https://test-issuer.com",
+						Keyset:        validKeyset,
+						SupportedAlgs: []string{"ES256"},
 					},
 					ClientID: "test-client-id",
 				}

--- a/jwt/provider.go
+++ b/jwt/provider.go
@@ -1,7 +1,35 @@
 package jwt
 
-type Provider interface {
-	GetIssuer() string
+// Issuer returns information about the issuer for tokens we want to verify
+// against.
+type Issuer interface {
+	// GetIssuerURL returns the URL of the issuer, which will correspond to the
+	// `iss` claim.
+	GetIssuerURL() string
+	// GetKeyset returns the keyset for the issuer, which will be used to verify
+	// the tokens.
 	GetKeyset() PublicKeyset
+	// GetSupportedAlgs returns the list of JWT algorithms supported by this
+	// issuer.
 	GetSupportedAlgs() []string
+}
+
+// StaticIssuer is a minimal implementation of the [Issuer] interface, to use
+// with fixed values. Most cases will discovery an OIDC or OAuth2 provider.
+type StaticIssuer struct {
+	IssuerURL     string
+	Keyset        PublicKeyset
+	SupportedAlgs []string
+}
+
+func (b *StaticIssuer) GetIssuerURL() string {
+	return b.IssuerURL
+}
+
+func (b *StaticIssuer) GetKeyset() PublicKeyset {
+	return b.Keyset
+}
+
+func (b *StaticIssuer) GetSupportedAlgs() []string {
+	return b.SupportedAlgs
 }

--- a/oauth2as/discovery/discovery_test.go
+++ b/oauth2as/discovery/discovery_test.go
@@ -48,8 +48,8 @@ func TestDiscovery(t *testing.T) {
 		t.Fatalf("failed to discover provider: %v", err)
 	}
 
-	if p.GetIssuer() != ts.URL {
-		t.Errorf("expected issuer %s, got %s", ts.URL, p.GetIssuer())
+	if p.GetIssuerURL() != ts.URL {
+		t.Errorf("expected issuer %s, got %s", ts.URL, p.GetIssuerURL())
 	}
 
 	keyset := p.GetKeyset()

--- a/oauth2as/keys.go
+++ b/oauth2as/keys.go
@@ -4,20 +4,16 @@ import (
 	"context"
 
 	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oauth2as/discovery"
 )
 
 type AlgorithmSigner interface {
-	// KeySet is used to determine the set of keys to serve on the discovery
-	// endpoint.
-	discovery.Keyset
-	// VerificationKeyset is used to verify issued tokens, e.g in the Userinfo
+	// PublicKeyset is used to verify issued tokens, i.e in the Userinfo
 	// endpoint.
 	jwt.PublicKeyset
 	// SignWithAlgorithm should sign the payload with the given algorithm and
 	// type header, and return the compact representation of the signed token.
 	SignWithAlgorithm(ctx context.Context, alg, typHdr string, payload []byte) (string, error)
-	// SupportedAlgorithms returns the list of algorithms supported by this
+	// SupportedAlgorithms returns the list of JWT algorithms supported by this
 	// signer.
 	SupportedAlgorithms() []string
 }

--- a/oauth2as/server_test.go
+++ b/oauth2as/server_test.go
@@ -551,7 +551,7 @@ func TestUserinfo(t *testing.T) {
 				req.Header.Set("authorization", "Bearer "+at)
 			}
 
-			oidc.Userinfo(rec, req)
+			oidc.UserinfoHandler(rec, req)
 			if tc.WantErr && rec.Result().StatusCode == http.StatusOK {
 				t.Error("want error, but got none")
 			}

--- a/oauth2as/server_token.go
+++ b/oauth2as/server_token.go
@@ -104,18 +104,17 @@ type TokenResponse struct {
 	EncryptedMetadata map[string]string
 }
 
-// Token is used to handle the access token endpoint for code flow requests.
-// This can handle both the initial access token request, as well as subsequent
-// calls for refreshes.
+// TokenHandler is used to handle the access token endpoint for code flow
+// requests. This can handle both the initial access token request, as well as
+// subsequent calls for refreshes.
 //
 // If a handler returns an error, it will be checked and the endpoint will
 // respond to the user appropriately. The session will not be invalidated
 // automatically, it it the responsibility of the handler to delete if it
-// requires this.
-// * If the error implements an `Unauthorized() bool` method and the result of
-// calling this is true, the caller will be notified of an `invalid_grant`. The
-// error text will be returned as the `error_description`
-// * All other errors will result an an InternalServerError
+// requires this. * If the error implements an `Unauthorized() bool` method and
+// the result of calling this is true, the caller will be notified of an
+// `invalid_grant`. The error text will be returned as the `error_description` *
+// All other errors will result an an InternalServerError
 //
 // This will always return a response to the user, regardless of success or
 // failure. As such, once returned the called can assume the HTTP request has
@@ -123,7 +122,12 @@ type TokenResponse struct {
 //
 // https://openid.net/specs/openid-connect-core-1_0.html#TokenEndpoint
 // https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens
-func (s *Server) Token(w http.ResponseWriter, req *http.Request) {
+func (s *Server) TokenHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+		return
+	}
+
 	treq, err := oauth2.ParseTokenRequest(req)
 	if err != nil {
 		_ = oauth2.WriteError(w, req, err)

--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -91,7 +91,7 @@ func (p *Provider) GetSupportedAlgs() []string {
 	return p.Metadata.IDTokenSigningAlgValuesSupported
 }
 
-func (p *Provider) GetIssuer() string {
+func (p *Provider) GetIssuerURL() string {
 	return p.Metadata.Issuer
 }
 


### PR DESCRIPTION
This is a remnant of the more full out of the box era, but now we're going more cut down it's not a core part so drop it. Consumers can set up their own discovery if/how they please.

Rename a few things, and provide a simple, static issuer.