### PR TITLE
Rename to lds.li/oauth2ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # oauth2ext
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/lstoll/oauth2ext.svg)](https://pkg.go.dev/github.com/lstoll/oauth2ext)
+[![Go Reference](https://pkg.go.dev/badge/lds.li/oauth2ext.svg)](https://pkg.go.dev/lds.li/oauth2ext)
 
 Module that provides extensions for to the [x/oauth2](https://pkg.go.dev/golang.org/x/oauth2) package, including OpenID connect (OIDC) usage.
 
-* [**oidc**](https://pkg.go.dev/github.com/lstoll/oauth2ext/oidc) Provides the ability to discover information from an OIDC issuer, and handle tokens that contain OIDC ID Tokens
-* [**jwt**](https://pkg.go.dev/github.com/lstoll/oauth2ext/jwt) Verification for OIDC ID and OAuth2 JWT Access tokens, as well as standard claim types.
-* [**clitoken**](https://pkg.go.dev/github.com/lstoll/oauth2ext/clitoken) Implements the three-legged OIDC flow for local/CLI applications, with a dynamic server on the loopback to handle the callback
-* [**oidcmiddleware**](https://pkg.go.dev/github.com/lstoll/oauth2ext/oidcmiddleware) Provides a HTTP middleware to secure a path against an OIDC issuer
-* [**tokencache**](https://pkg.go.dev/github.com/lstoll/oauth2ext/tokencache) Provides a mechanism for caching and refreshing tokens.
+* [**oidc**](https://pkg.go.dev/lds.li/oauth2ext/oidc) Provides the ability to discover information from an OIDC issuer, and handle tokens that contain OIDC ID Tokens
+* [**jwt**](https://pkg.go.dev/lds.li/oauth2ext/jwt) Verification for OIDC ID and OAuth2 JWT Access tokens, as well as standard claim types.
+* [**clitoken**](https://pkg.go.dev/lds.li/oauth2ext/clitoken) Implements the three-legged OIDC flow for local/CLI applications, with a dynamic server on the loopback to handle the callback
+* [**oidcmiddleware**](https://pkg.go.dev/lds.li/oauth2ext/oidcmiddleware) Provides a HTTP middleware to secure a path against an OIDC issuer
+* [**tokencache**](https://pkg.go.dev/lds.li/oauth2ext/tokencache) Provides a mechanism for caching and refreshing tokens.
 
 Examples:
 * **cmd/oidc-example-rp** An example of a webapp that authenticates via OIDC
-* **cmd/oidcli** A CLI tool that uses the [clitoken](https://pkg.go.dev/github.com/lstoll/oauth2ext/clitoken) package to retrieve ID/Access tokens, and return them or information about them.
+* **cmd/oidcli** A CLI tool that uses the [clitoken](https://pkg.go.dev/lds.li/oauth2ext/clitoken) package to retrieve ID/Access tokens, and return them or information about them.

--- a/clitoken/cache.go
+++ b/clitoken/cache.go
@@ -8,9 +8,9 @@ import (
 	"os/exec"
 	"runtime"
 
-	"github.com/lstoll/oauth2ext/oidc"
-	"github.com/lstoll/oauth2ext/tokencache"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/oidc"
+	"lds.li/oauth2ext/tokencache"
 )
 
 var (

--- a/clitoken/cache_darwin_cgo.go
+++ b/clitoken/cache_darwin_cgo.go
@@ -11,10 +11,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/lstoll/oauth2ext/internal/keychain"
-	"github.com/lstoll/oauth2ext/oidc"
-	"github.com/lstoll/oauth2ext/tokencache"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal/keychain"
+	"lds.li/oauth2ext/oidc"
+	"lds.li/oauth2ext/tokencache"
 )
 
 func init() {

--- a/clitoken/cache_test.go
+++ b/clitoken/cache_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/lstoll/oauth2ext/tokencache"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/tokencache"
 )
 
 func TestKeychainCLICredentialCache(t *testing.T) {

--- a/cmd/oidc-example-rp/main.go
+++ b/cmd/oidc-example-rp/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/oidc"
 )
 
 const (

--- a/cmd/oidc-example-rp/server.go
+++ b/cmd/oidc-example-rp/server.go
@@ -10,8 +10,8 @@ import (
 
 	"net/http"
 
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/oidc"
 )
 
 const (

--- a/cmd/oidccli/main.go
+++ b/cmd/oidccli/main.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lstoll/oauth2ext/clitoken"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oidc"
-	"github.com/lstoll/oauth2ext/oidcclientreg"
-	"github.com/lstoll/oauth2ext/tokencache"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/clitoken"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oidc"
+	"lds.li/oauth2ext/oidcclientreg"
+	"lds.li/oauth2ext/tokencache"
 )
 
 type subCommand struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lstoll/oauth2ext
+module lds.li/oauth2ext
 
 go 1.24.0
 

--- a/jwt/at_verifier_test.go
+++ b/jwt/at_verifier_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lstoll/oauth2ext/internal"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
 )
 
 func TestAccessTokenVerifier_VerifyRaw(t *testing.T) {

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/lstoll/oauth2ext/internal/th"
+	"lds.li/oauth2ext/internal/th"
 )
 
 func TestClaimsJSONRoundtrip(t *testing.T) {

--- a/jwt/claims_types_test.go
+++ b/jwt/claims_types_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/lstoll/oauth2ext/internal/th"
+	"lds.li/oauth2ext/internal/th"
 )
 
 func TestCustomMarshaling(t *testing.T) {

--- a/jwt/id_verifier_test.go
+++ b/jwt/id_verifier_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lstoll/oauth2ext/internal"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
 )
 
 func TestIDTokenVerifier_VerifyRaw(t *testing.T) {

--- a/jwt/verifier_test.go
+++ b/jwt/verifier_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
-	"github.com/lstoll/oauth2ext/internal"
+	"lds.li/oauth2ext/internal"
 )
 
 func TestVerifyToken(t *testing.T) {

--- a/oauth2as/README.md
+++ b/oauth2as/README.md
@@ -1,6 +1,6 @@
 # oauth2as
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/lstoll/oauth2ext/oauth2as.svg)](https://pkg.go.dev/github.com/lstoll/oauth2ext/oauth2as)
+[![Go Reference](https://pkg.go.dev/badge/lds.li/oauth2ext/oauth2as.svg)](https://pkg.go.dev/lds.li/oauth2ext/oauth2as)
 
 Go library for implementing Oauth2/OIDC OPs (Servers). In active development
 

--- a/oauth2as/client.go
+++ b/oauth2as/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/lstoll/oauth2ext/jwt"
+	"lds.li/oauth2ext/jwt"
 )
 
 type clientOpts struct {

--- a/oauth2as/discovery/configuration_handler.go
+++ b/oauth2as/discovery/configuration_handler.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oidc"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oidc"
 )
 
 const DefaultCacheFor = 1 * time.Minute

--- a/oauth2as/discovery/discovery_test.go
+++ b/oauth2as/discovery/discovery_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lstoll/oauth2ext/internal"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oauth2as/discovery"
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oauth2as/discovery"
+	"lds.li/oauth2ext/oidc"
 )
 
 func TestDiscovery(t *testing.T) {

--- a/oauth2as/e2e_test.go
+++ b/oauth2as/e2e_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oauth2as"
-	"github.com/lstoll/oauth2ext/oauth2as/discovery"
-	"github.com/lstoll/oauth2ext/oauth2as/internal"
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oauth2as"
+	"lds.li/oauth2ext/oauth2as/discovery"
+	"lds.li/oauth2ext/oauth2as/internal"
+	"lds.li/oauth2ext/oidc"
 )
 
 func TestE2E(t *testing.T) {

--- a/oauth2as/internal/test_signer.go
+++ b/oauth2as/internal/test_signer.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	josejson "github.com/go-jose/go-jose/v4/json"
-	"github.com/lstoll/oauth2ext/jwt"
+	"lds.li/oauth2ext/jwt"
 )
 
 type testSignerKey struct {

--- a/oauth2as/keys.go
+++ b/oauth2as/keys.go
@@ -3,7 +3,7 @@ package oauth2as
 import (
 	"context"
 
-	"github.com/lstoll/oauth2ext/jwt"
+	"lds.li/oauth2ext/jwt"
 )
 
 type AlgorithmSigner interface {

--- a/oauth2as/server.go
+++ b/oauth2as/server.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/lstoll/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/internal/oauth2"
 )
 
 const (

--- a/oauth2as/server_authorization.go
+++ b/oauth2as/server_authorization.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/oauth2"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/token"
+	"lds.li/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/internal/token"
 )
 
 type AuthRequest struct {

--- a/oauth2as/server_test.go
+++ b/oauth2as/server_test.go
@@ -18,11 +18,11 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oauth2as/internal"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/oauth2"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/token"
-	"github.com/lstoll/oauth2ext/oidc"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oauth2as/internal"
+	"lds.li/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/internal/token"
+	"lds.li/oauth2ext/oidc"
 )
 
 type unauthorizedErrImpl struct{ error }

--- a/oauth2as/server_token.go
+++ b/oauth2as/server_token.go
@@ -14,10 +14,10 @@ import (
 
 	josejson "github.com/go-jose/go-jose/v4/json"
 	"github.com/google/uuid"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/oauth2"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/token"
-	"github.com/lstoll/oauth2ext/oidc"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/internal/token"
+	"lds.li/oauth2ext/oidc"
 )
 
 const (

--- a/oauth2as/server_userinfo.go
+++ b/oauth2as/server_userinfo.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oauth2as/internal/oauth2"
 )
 
 type UserinfoHandler func(ctx context.Context, uireq *UserinfoRequest) (*UserinfoResponse, error)

--- a/oidc/id_token_source.go
+++ b/oidc/id_token_source.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lstoll/oauth2ext/internal"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
 )
 
 // NewIDTokenSource wraps a token source, re-writing the ID token as the access

--- a/oidc/provider.go
+++ b/oidc/provider.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	josejson "github.com/go-jose/go-jose/v4/json"
-	"github.com/lstoll/oauth2ext/internal"
-	"github.com/lstoll/oauth2ext/jwt"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
+	"lds.li/oauth2ext/jwt"
 )
 
 const DefaultProviderCacheDuration = 15 * time.Minute

--- a/oidc/provider_test.go
+++ b/oidc/provider_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/lstoll/oauth2ext/internal"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
 )
 
 func TestProviderDiscovery(t *testing.T) {

--- a/oidcclientreg/register.go
+++ b/oidcclientreg/register.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/lstoll/oauth2ext/internal"
-	"github.com/lstoll/oauth2ext/oidc"
+	"lds.li/oauth2ext/internal"
+	"lds.li/oauth2ext/oidc"
 )
 
 func RegisterWithProvider(ctx context.Context, provider *oidc.Provider, request *ClientRegistrationRequest) (*ClientRegistrationResponse, error) {

--- a/oidcclientreg/register_test.go
+++ b/oidcclientreg/register_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/oidc"
 )
 
 func TestRegisterWithProvider(t *testing.T) {

--- a/oidcmiddleware/cookie_state.go
+++ b/oidcmiddleware/cookie_state.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lstoll/oauth2ext/internal"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oidc"
 )
 
 const DefaultMaxActiveLoginStates = 5

--- a/oidcmiddleware/cookie_state_test.go
+++ b/oidcmiddleware/cookie_state_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/oidc"
 )
 
 func TestCookiestore_SaveGetOIDCSession(t *testing.T) {

--- a/oidcmiddleware/middleware.go
+++ b/oidcmiddleware/middleware.go
@@ -9,9 +9,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oidc"
 )
 
 const loginStateExpiresAfter = 5 * time.Minute

--- a/oidcmiddleware/middleware_test.go
+++ b/oidcmiddleware/middleware_test.go
@@ -15,10 +15,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lstoll/oauth2ext/internal"
-	"github.com/lstoll/oauth2ext/jwt"
-	"github.com/lstoll/oauth2ext/oidc"
 	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/internal"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/oidc"
 )
 
 // mockOIDCServer mocks out just enough of an OIDC server for tests. It accepts


### PR DESCRIPTION
Not sure GitHub is going to be the forever home for this code. Much like e-mail, use a domain which I control so that can be changed in the future.