### PR TITLE
keychain: Fallback to binary hash for all codesig errors

### DIFF
--- a/internal/keychain/binary_identity_test.go
+++ b/internal/keychain/binary_identity_test.go
@@ -2,10 +2,19 @@
 
 package keychain
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 func TestGetSelfCDHashes(t *testing.T) {
-	hash, err := GetSelfCDHashes()
+	if runtime.GOARCH != "arm64" {
+		// would also be supported in signed bins, but test bins wouldn't be
+		// signed so.
+		t.Skip("GetSelfCDHashes is only supported on arm64")
+		return
+	}
+	hash, err := getSelfCDHashes()
 	if err != nil {
 		t.Fatalf("GetSelfCDHash failed: %v", err)
 	}

--- a/internal/keychain/types.go
+++ b/internal/keychain/types.go
@@ -13,8 +13,9 @@ import "C"
 import "unsafe"
 
 var (
-	nilCFStringRef C.CFStringRef
-	nilCFDataRef   C.CFDataRef
+	nilCFStringRef       C.CFStringRef
+	nilCFDataRef         C.CFDataRef
+	nilSecRequirementRef C.SecRequirementRef
 )
 
 // stringToCFString creates a new CFStringRef from a Go string.


### PR DESCRIPTION
Currently this doesn't work on Intel CPU Macs. The Go binaries aren't ad-hoc signed on that platform, and our current error check doesn't handle the actual error returned. Update it to just fall back to binary hash if any error occurs. I don't think we're likely to end up in a state here where we flap between the two, and we test them independently so it's not likely to hide implementation errors.