### PR TITLE
provider: Take context, validate ACR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Module that provides extensions for to the [x/oauth2](https://pkg.go.dev/golang.
 
 Examples:
 * **cmd/oidc-example-rp** An example of a webapp that authenticates via OIDC
-* (**oidcli**)[https://github.com/lstoll/oidccli] A CLI tool that uses the [clitoken](https://pkg.go.dev/lds.li/oauth2ext/clitoken) package to retrieve ID/Access tokens, and return them or information about them.
+* [**oidcli**](https://github.com/lstoll/oidccli) A CLI tool that uses the [clitoken](https://pkg.go.dev/lds.li/oauth2ext/clitoken) package to retrieve ID/Access tokens, and return them or information about them.

--- a/cmd/oidc-example-rp/server.go
+++ b/cmd/oidc-example-rp/server.go
@@ -140,7 +140,7 @@ func (s *server) callback(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, fmt.Sprintf("error creating ID token validator: %v", err), http.StatusInternalServerError)
 			return
 		}
-		idToken, err := s.provider.VerifyAndDecodeIDToken(token, validator)
+		idToken, err := s.provider.VerifyAndDecodeIDToken(req.Context(), token, validator)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error verifying ID token: %v", err), http.StatusInternalServerError)
 			return

--- a/oidcmiddleware/middleware.go
+++ b/oidcmiddleware/middleware.go
@@ -201,7 +201,7 @@ func (h *Handler) authenticateExisting(r *http.Request, session *SessionData) (*
 
 	// we always verify, as in the cookie store case the integrity of the data
 	// is not trusted.
-	jwt, err := h.Provider.VerifyAndDecodeIDToken(session.Token.Token, validator)
+	jwt, err := h.Provider.VerifyAndDecodeIDToken(ctx, session.Token.Token, validator)
 	if err != nil {
 		// Attempt to refresh the token
 		if session.Token.RefreshToken == "" {
@@ -212,7 +212,7 @@ func (h *Handler) authenticateExisting(r *http.Request, session *SessionData) (*
 			return nil, nil
 		}
 		session.Token = &oidc.TokenWithID{Token: token}
-		jwt, err = h.Provider.VerifyAndDecodeIDToken(token, validator)
+		jwt, err = h.Provider.VerifyAndDecodeIDToken(ctx, token, validator)
 		if err != nil {
 			return nil, nil
 		}
@@ -288,7 +288,7 @@ func (h *Handler) authenticateCallback(r *http.Request, session *SessionData) (s
 	if err != nil {
 		return "", err
 	}
-	if _, err := h.Provider.VerifyAndDecodeIDToken(token, validator); err != nil {
+	if _, err := h.Provider.VerifyAndDecodeIDToken(ctx, token, validator); err != nil {
 		return "", fmt.Errorf("verifying id_token failed: %w", err)
 	}
 

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -3,10 +3,14 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/tink-crypto/tink-go/v2/jwt"
 	"golang.org/x/oauth2"
 	"lds.li/oauth2ext/internal"
 )
@@ -89,4 +93,217 @@ func newMockDiscoveryServer(t *testing.T) (*httptest.Server, *internal.TestSigne
 	svr.Config.Handler = mux
 
 	return svr, testSigner
+}
+
+func TestIDTokenValidator(t *testing.T) {
+	svr, testSigner := newMockDiscoveryServer(t)
+	issuer := svr.URL
+	clientID := "test-client-id"
+
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, svr.Client())
+	p, err := DiscoverOIDCProvider(ctx, issuer)
+	if err != nil {
+		t.Fatalf("failed to discover provider: %v", err)
+	}
+
+	createIDToken := func(iss, aud string, acr *string, customClaims map[string]any) *oauth2.Token {
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			Issuer:    &iss,
+			Audience:  &aud,
+			Subject:   ptr("test-subject"),
+			IssuedAt:  &now,
+			ExpiresAt: ptr(now.Add(time.Hour)),
+		}
+		if opts.CustomClaims == nil {
+			opts.CustomClaims = make(map[string]any)
+		}
+		if acr != nil {
+			opts.CustomClaims["acr"] = *acr
+		}
+		maps.Copy(opts.CustomClaims, customClaims)
+
+		rawJWT, err := jwt.NewRawJWT(opts)
+		if err != nil {
+			t.Fatalf("failed to create raw JWT: %v", err)
+		}
+
+		signed, err := testSigner.Sign(rawJWT)
+		if err != nil {
+			t.Fatalf("failed to sign JWT: %v", err)
+		}
+
+		return (&oauth2.Token{
+			AccessToken: "access-token",
+		}).WithExtra(map[string]any{
+			"id_token": signed,
+		})
+	}
+
+	tests := []struct {
+		name    string
+		opts    *IDTokenValidatorOpts
+		token   func() *oauth2.Token
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid token with matching client ID",
+			opts: &IDTokenValidatorOpts{
+				ClientID: &clientID,
+			},
+			token: func() *oauth2.Token {
+				return createIDToken(issuer, clientID, nil, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid token with matching client ID and ACR",
+			opts: &IDTokenValidatorOpts{
+				ClientID:  &clientID,
+				ACRValues: []string{"urn:mace:incommon:iap:silver"},
+			},
+			token: func() *oauth2.Token {
+				acr := "urn:mace:incommon:iap:silver"
+				return createIDToken(issuer, clientID, &acr, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid token with ACR in allowed list",
+			opts: &IDTokenValidatorOpts{
+				ClientID:  &clientID,
+				ACRValues: []string{"urn:mace:incommon:iap:silver", "urn:mace:incommon:iap:gold"},
+			},
+			token: func() *oauth2.Token {
+				acr := "urn:mace:incommon:iap:gold"
+				return createIDToken(issuer, clientID, &acr, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid token with IgnoreClientID",
+			opts: &IDTokenValidatorOpts{
+				IgnoreClientID: true,
+			},
+			token: func() *oauth2.Token {
+				return createIDToken(issuer, "different-client-id", nil, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid token with wrong issuer",
+			opts: &IDTokenValidatorOpts{
+				ClientID: &clientID,
+			},
+			token: func() *oauth2.Token {
+				return createIDToken("https://wrong-issuer.com", clientID, nil, nil)
+			},
+			wantErr: true,
+			errMsg:  "validating issuer claim",
+		},
+		{
+			name: "invalid token with wrong audience",
+			opts: &IDTokenValidatorOpts{
+				ClientID: &clientID,
+			},
+			token: func() *oauth2.Token {
+				return createIDToken(issuer, "wrong-client-id", nil, nil)
+			},
+			wantErr: true,
+			errMsg:  "audience",
+		},
+		{
+			name: "invalid token with missing ACR when required",
+			opts: &IDTokenValidatorOpts{
+				ClientID:  &clientID,
+				ACRValues: []string{"urn:mace:incommon:iap:silver"},
+			},
+			token: func() *oauth2.Token {
+				return createIDToken(issuer, clientID, nil, nil)
+			},
+			wantErr: true,
+			errMsg:  "ACR claim found",
+		},
+		{
+			name: "invalid token with wrong ACR value",
+			opts: &IDTokenValidatorOpts{
+				ClientID:  &clientID,
+				ACRValues: []string{"urn:mace:incommon:iap:silver"},
+			},
+			token: func() *oauth2.Token {
+				acr := "urn:mace:incommon:iap:bronze"
+				return createIDToken(issuer, clientID, &acr, nil)
+			},
+			wantErr: true,
+			errMsg:  "not in requested list",
+		},
+		{
+			name: "invalid token with ACR as non-string",
+			opts: &IDTokenValidatorOpts{
+				ClientID:  &clientID,
+				ACRValues: []string{"urn:mace:incommon:iap:silver"},
+			},
+			token: func() *oauth2.Token {
+				return createIDToken(issuer, clientID, nil, map[string]any{
+					"acr": 123, // ACR should be a string
+				})
+			},
+			wantErr: true,
+			errMsg:  "ACR claim found",
+		},
+		{
+			name: "valid token with no opts and IgnoreClientID",
+			opts: &IDTokenValidatorOpts{
+				IgnoreClientID: true,
+			},
+			token: func() *oauth2.Token {
+				return createIDToken(issuer, clientID, nil, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid token missing id_token in extra",
+			opts: &IDTokenValidatorOpts{
+				ClientID: &clientID,
+			},
+			token: func() *oauth2.Token {
+				return (&oauth2.Token{
+					AccessToken: "access-token",
+				}).WithExtra(map[string]any{})
+			},
+			wantErr: true,
+			errMsg:  "no id_token found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, err := p.NewIDTokenValidator(tt.opts)
+			if err != nil {
+				t.Fatalf("failed to create validator: %v", err)
+			}
+
+			token := tt.token()
+			verified, err := p.VerifyAndDecodeIDToken(t.Context(), token, validator)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error message should contain %q, got: %v", tt.errMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if verified == nil {
+					t.Errorf("expected verified JWT but got nil")
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
These can make network requests, best to make our validation methods take a context where possible.

Update ID token validation to validate ACR values.