### PR TITLE
Validate redirect URI on token endpoint

### DIFF
--- a/oauth2as/server_test.go
+++ b/oauth2as/server_test.go
@@ -218,6 +218,12 @@ func TestCodeToken(t *testing.T) {
 			AuthCode:      newToken.Stored(),
 			GrantedAt:     time.Now(),
 			ExpiresAt:     time.Now().Add(1 * time.Minute),
+			Request: &AuthRequest{
+				ClientID:    es256ClientID,
+				RedirectURI: es256ClientRedirect,
+				State:       "",
+				Scopes:      []string{oidc.ScopeOfflineAccess},
+			},
 		}
 
 		if err := o.config.Storage.CreateGrant(context.Background(), grant); err != nil {
@@ -227,7 +233,7 @@ func TestCodeToken(t *testing.T) {
 		treq := &oauth2.TokenRequest{
 			GrantType:    oauth2.GrantTypeAuthorizationCode,
 			Code:         newToken.User(),
-			RedirectURI:  redirectURI,
+			RedirectURI:  es256ClientRedirect,
 			ClientID:     es256ClientID,
 			ClientSecret: es256ClientSecret,
 		}
@@ -621,6 +627,12 @@ func newCodeGrant(t *testing.T, smgr Storage) (authCode string) {
 		AuthCode:      newToken.Stored(),
 		GrantedAt:     time.Now(),
 		ExpiresAt:     time.Now().Add(1 * time.Minute),
+		Request: &AuthRequest{
+			ClientID:    "client-id",
+			RedirectURI: "https://redirect",
+			State:       "",
+			Scopes:      []string{oidc.ScopeOfflineAccess},
+		},
 	}
 
 	if err := smgr.CreateGrant(context.Background(), grant); err != nil {

--- a/oauth2as/server_token.go
+++ b/oauth2as/server_token.go
@@ -175,6 +175,14 @@ func (s *Server) codeToken(ctx context.Context, treq *oauth2.TokenRequest) (*oau
 	if grant == nil {
 		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid code"}
 	}
+	if grant.Request == nil {
+		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid grant"}
+	}
+
+	// Validate that the redirect_uri matches the one from the authorization request
+	if treq.RedirectURI != grant.Request.RedirectURI {
+		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "redirect URI mismatch"}
+	}
 
 	// update to note the code was used.
 	oldAuthCode := grant.AuthCode


### PR DESCRIPTION
We were not doing this, but we should. This now correctly ensures that the presented redirect_uri on the token endpoint matches the one the flow was started with.