### PR TITLE
claimgen: Handle string slices better, check custom claims

### DIFF
--- a/claims/claims.json
+++ b/claims/claims.json
@@ -125,7 +125,7 @@
     {
       "claim": "amr",
       "method": "AMR",
-      "type": "array",
+      "type": "stringarray",
       "description": "Authentication Methods References. This is an array of strings that are identifiers for authentication methods used in the authentication. For example, values might include \"pwd\" for password, \"otp\" for one-time password, etc."
     },
     {

--- a/claims/id_claims_test.go
+++ b/claims/id_claims_test.go
@@ -2,6 +2,7 @@ package claims
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"strings"
 	"testing"
@@ -24,10 +25,17 @@ func TestIDClaims(t *testing.T) {
 		AMR:       []string{"amr1", "amr2"},
 	}
 
-	_, err := jwt.NewRawJWT(rawOpts.JWTOptions())
+	rOps, err := rawOpts.JWTOptions()
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	_, err = jwt.NewRawJWT(rOps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(rOps)
 }
 
 func TestIDTokenValidator(t *testing.T) {


### PR DESCRIPTION
Add a `stringarray` type to the claims generator, that will convert the []any to []string. This makes it easier to work with string array claims better.

Check if a claim is reserved, and block it in custom claims -> raw JWT. If we have a field for it, it should be used.