### PR TITLE
dpop: JWT Support

### DIFF
--- a/dpop/doc.go
+++ b/dpop/doc.go
@@ -1,0 +1,3 @@
+// Package dpop provides utilities for working with DPoP JWTs, and
+// sending/verifying them on requests.
+package dpop

--- a/dpop/jwk.go
+++ b/dpop/jwk.go
@@ -1,0 +1,323 @@
+package dpop
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+	"github.com/tink-crypto/tink-go/v2/jwt/jwtecdsa"
+	"github.com/tink-crypto/tink-go/v2/jwt/jwtrsassapkcs1"
+	"github.com/tink-crypto/tink-go/v2/key"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+)
+
+// publicKeyToJWK creates a JWK representation of a public key for use in DPoP tokens.
+// It uses Tink to convert the public key to a JWK set and extracts the first key.
+// It returns a map that can be used as the "jwk" header value.
+func publicKeyToJWK(pubKey crypto.PublicKey) (map[string]any, error) {
+	alg, err := determineAlgorithmFromKey(pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("determining algorithm: %w", err)
+	}
+
+	header := map[string]any{
+		"alg": alg,
+	}
+
+	handle, err := createKeysetHandleFromPublicKey(pubKey, header)
+	if err != nil {
+		return nil, fmt.Errorf("creating keyset handle: %w", err)
+	}
+
+	jwkSetJSON, err := jwt.JWKSetFromPublicKeysetHandle(handle)
+	if err != nil {
+		return nil, fmt.Errorf("converting to JWK set: %w", err)
+	}
+
+	var jwkSet struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.Unmarshal(jwkSetJSON, &jwkSet); err != nil {
+		return nil, fmt.Errorf("parsing JWK set: %w", err)
+	}
+
+	if len(jwkSet.Keys) == 0 {
+		return nil, fmt.Errorf("JWK set is empty")
+	}
+
+	jwk := jwkSet.Keys[0]
+	// remove alg if present, as it's not part of the jwk header per RFC 9449
+	delete(jwk, "alg")
+
+	return jwk, nil
+}
+
+// determineAlgorithmFromKey determines the JWT algorithm from a public key type.
+func determineAlgorithmFromKey(pubKey any) (string, error) {
+	switch key := pubKey.(type) {
+	case *rsa.PublicKey:
+		// Default to RS256 for RSA keys TODO - do we want to support other
+		// algs? Would need it to be an opt somewhere.
+		return "RS256", nil
+	case *ecdsa.PublicKey:
+		switch key.Curve.Params().BitSize {
+		case 256:
+			return "ES256", nil
+		case 384:
+			return "ES384", nil
+		case 521:
+			return "ES512", nil
+		default:
+			return "", fmt.Errorf("unsupported ECDSA curve size: %d", key.Curve.Params().BitSize)
+		}
+	default:
+		return "", fmt.Errorf("unsupported public key type: %T", pubKey)
+	}
+}
+
+// createKeysetHandleFromPublicKey creates a tink keyset handle from a public key.
+// If header["alg"] is missing, the algorithm is determined from the key type.
+func createKeysetHandleFromPublicKey(pubKey any, header map[string]any) (*keyset.Handle, error) {
+	var alg string
+	var ok bool
+	if header != nil {
+		alg, ok = header["alg"].(string)
+	}
+	if !ok {
+		// Determine algorithm from key type
+		var err error
+		alg, err = determineAlgorithmFromKey(pubKey)
+		if err != nil {
+			return nil, fmt.Errorf("missing alg in header and could not determine from key: %w", err)
+		}
+	}
+
+	manager := keyset.NewManager()
+
+	var tinkKey key.Key
+	var err error
+
+	switch key := pubKey.(type) {
+	case *rsa.PublicKey:
+		if !strings.HasPrefix(alg, "RS") {
+			return nil, fmt.Errorf("algorithm %s does not match RSA key type", alg)
+		}
+		tinkKey, err = createRSAPublicKey(key, alg)
+	case *ecdsa.PublicKey:
+		if !strings.HasPrefix(alg, "ES") {
+			return nil, fmt.Errorf("algorithm %s does not match ECDSA key type", alg)
+		}
+		tinkKey, err = createECDSAPublicKey(key, alg)
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %T", pubKey)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("creating tink public key: %w", err)
+	}
+
+	keyID, err := manager.AddKey(tinkKey)
+	if err != nil {
+		return nil, fmt.Errorf("adding key to manager: %w", err)
+	}
+
+	// Set the key as primary, the handle needs one.
+	if err := manager.SetPrimary(keyID); err != nil {
+		return nil, fmt.Errorf("setting primary key: %w", err)
+	}
+
+	handle, err := manager.Handle()
+	if err != nil {
+		return nil, fmt.Errorf("getting handle from manager: %w", err)
+	}
+
+	return handle, nil
+}
+
+// createECDSAPublicKey creates a jwtecdsa.PublicKey from an ECDSA public key.
+func createECDSAPublicKey(pubKey *ecdsa.PublicKey, alg string) (*jwtecdsa.PublicKey, error) {
+	var algorithm jwtecdsa.Algorithm
+	switch alg {
+	case "ES256":
+		algorithm = jwtecdsa.ES256
+		if pubKey.Curve.Params().BitSize != 256 {
+			return nil, fmt.Errorf("algorithm ES256 requires P-256 curve, got curve with %d bits", pubKey.Curve.Params().BitSize)
+		}
+	case "ES384":
+		algorithm = jwtecdsa.ES384
+		if pubKey.Curve.Params().BitSize != 384 {
+			return nil, fmt.Errorf("algorithm ES384 requires P-384 curve, got curve with %d bits", pubKey.Curve.Params().BitSize)
+		}
+	case "ES512":
+		algorithm = jwtecdsa.ES512
+		if pubKey.Curve.Params().BitSize != 521 {
+			return nil, fmt.Errorf("algorithm ES512 requires P-521 curve, got curve with %d bits", pubKey.Curve.Params().BitSize)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported ECDSA algorithm: %s", alg)
+	}
+
+	params, err := jwtecdsa.NewParameters(jwtecdsa.IgnoredKID, algorithm)
+	if err != nil {
+		return nil, fmt.Errorf("creating parameters: %w", err)
+	}
+
+	publicPoint, err := pubKey.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("getting public key bytes: %w", err)
+	}
+
+	return jwtecdsa.NewPublicKey(jwtecdsa.PublicKeyOpts{
+		PublicPoint: publicPoint,
+		Parameters:  params,
+	})
+}
+
+// createRSAPublicKey creates a jwtrsassapkcs1.PublicKey from an RSA public key.
+func createRSAPublicKey(pubKey *rsa.PublicKey, alg string) (*jwtrsassapkcs1.PublicKey, error) {
+	var algorithm jwtrsassapkcs1.Algorithm
+	switch alg {
+	case "RS256":
+		algorithm = jwtrsassapkcs1.RS256
+	case "RS384":
+		algorithm = jwtrsassapkcs1.RS384
+	case "RS512":
+		algorithm = jwtrsassapkcs1.RS512
+	default:
+		return nil, fmt.Errorf("unsupported RSA algorithm: %s", alg)
+	}
+
+	paramsOpts := jwtrsassapkcs1.ParametersOpts{
+		ModulusSizeInBits: pubKey.N.BitLen(),
+		PublicExponent:    pubKey.E,
+		KidStrategy:       jwtrsassapkcs1.IgnoredKID,
+		Algorithm:         algorithm,
+	}
+	params, err := jwtrsassapkcs1.NewParameters(paramsOpts)
+	if err != nil {
+		return nil, fmt.Errorf("creating parameters: %w", err)
+	}
+
+	return jwtrsassapkcs1.NewPublicKey(jwtrsassapkcs1.PublicKeyOpts{
+		Modulus:    pubKey.N.Bytes(),
+		Parameters: params,
+	})
+}
+
+// canonicalizeJWK creates a canonical JSON representation of a JWK per RFC 7638.
+// Keys are sorted alphabetically with no whitespace.
+func canonicalizeJWK(jwk map[string]any) ([]byte, error) {
+	kty, ok := jwk["kty"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing required member: kty")
+	}
+
+	var requiredKeys []string
+	canonicalMap := make(map[string]any)
+
+	canonicalMap["kty"] = kty
+
+	switch kty {
+	case "EC":
+		// EC keys require: kty, crv, x, y
+		crv, ok := jwk["crv"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for EC key: crv")
+		}
+		x, ok := jwk["x"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for EC key: x")
+		}
+		y, ok := jwk["y"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for EC key: y")
+		}
+		canonicalMap["crv"] = crv
+		canonicalMap["x"] = x
+		canonicalMap["y"] = y
+		requiredKeys = []string{"crv", "kty", "x", "y"}
+
+	case "RSA":
+		// RSA keys require: kty, n, e
+		n, ok := jwk["n"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for RSA key: n")
+		}
+		e, ok := jwk["e"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for RSA key: e")
+		}
+		canonicalMap["e"] = e
+		canonicalMap["n"] = n
+		requiredKeys = []string{"e", "kty", "n"}
+
+	case "OKP":
+		// OKP (Octet Key Pair) keys require: kty, crv, x
+		crv, ok := jwk["crv"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for OKP key: crv")
+		}
+		x, ok := jwk["x"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing required member for OKP key: x")
+		}
+		canonicalMap["crv"] = crv
+		canonicalMap["x"] = x
+		requiredKeys = []string{"crv", "kty", "x"}
+
+	default:
+		return nil, fmt.Errorf("unsupported key type for thumbprint: %s", kty)
+	}
+
+	// Sort keys lexicographically (RFC 7638)
+	sort.Strings(requiredKeys)
+
+	// Build canonical JSON with no whitespace
+	var parts []string
+	for _, k := range requiredKeys {
+		v := canonicalMap[k]
+		valStr, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected non-string value for key %s", k)
+		}
+		// JSON encode both key and value
+		valJSON, err := json.Marshal(valStr)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling value for key %s: %w", k, err)
+		}
+		keyJSON, err := json.Marshal(k)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling key %s: %w", k, err)
+		}
+		parts = append(parts, string(keyJSON)+":"+string(valJSON))
+	}
+
+	canonicalJSON := "{" + strings.Join(parts, ",") + "}"
+
+	return []byte(canonicalJSON), nil
+}
+
+// calculateJWKThumbprint calculates the JWK thumbprint per RFC 7638.
+// Returns the base64url-encoded SHA-256 hash of the canonical JWK.
+func calculateJWKThumbprint(jwk any) (string, error) {
+	jwkMap, ok := jwk.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("jwk is not a map")
+	}
+
+	canonical, err := canonicalizeJWK(jwkMap)
+	if err != nil {
+		return "", fmt.Errorf("canonicalizing JWK: %w", err)
+	}
+
+	hash := sha256.Sum256(canonical)
+
+	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
+}

--- a/dpop/jwk_test.go
+++ b/dpop/jwk_test.go
@@ -1,0 +1,39 @@
+package dpop
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestJWKThumbprint_RFC7638_Example(t *testing.T) {
+	// Test using the exact RSA JWK example from RFC 7638
+	// This verifies our implementation matches the RFC specification
+	jwk := map[string]any{
+		"kty": "RSA",
+		"n":   "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+		"e":   "AQAB",
+		"alg": "RS256",
+		"kid": "2011-04-29",
+	}
+
+	thumbprint, err := calculateJWKThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	// Expected SHA-256 hash from RFC 7638 (as byte array)
+	expectedHash := []byte{
+		55, 54, 203, 177, 120, 124, 184, 48, 156, 119, 238, 140, 55, 5, 197,
+		225, 111, 251, 158, 133, 151, 21, 144, 31, 30, 76, 89, 177, 17, 130,
+		245, 123,
+	}
+
+	// Convert expected hash to base64url
+	expectedThumbprint := base64.RawURLEncoding.EncodeToString(expectedHash)
+
+	if thumbprint != expectedThumbprint {
+		t.Errorf("thumbprint does not match RFC 7638 example:\n  got:      %s\n  expected: %s", thumbprint, expectedThumbprint)
+	}
+
+	t.Logf("RFC 7638 example thumbprint: %s", thumbprint)
+}

--- a/dpop/jwt.go
+++ b/dpop/jwt.go
@@ -1,0 +1,46 @@
+package dpop
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// parseToken parses a JWT token string into its three parts: header, claims, and signature.
+// Returns ok=false if the token format is invalid (must have exactly 2 periods).
+func parseToken(s string) (header, claims, sig string, ok bool) {
+	header, s, ok = strings.Cut(s, ".")
+	if !ok { // no period found
+		return "", "", "", false
+	}
+	claims, s, ok = strings.Cut(s, ".")
+	if !ok { // only one period found
+		return "", "", "", false
+	}
+	sig, _, ok = strings.Cut(s, ".")
+	if ok { // three periods found (more than expected)
+		return "", "", "", false
+	}
+	return header, claims, sig, true
+}
+
+// parseJWTHeader extracts and parses the JWT header from a compact JWT string.
+func parseJWTHeader(compact string) (map[string]any, error) {
+	headerB64, _, _, ok := parseToken(compact)
+	if !ok {
+		return nil, fmt.Errorf("malformed JWT: expected format header.payload.signature")
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(headerB64)
+	if err != nil {
+		return nil, fmt.Errorf("decoding header: %w", err)
+	}
+
+	var header map[string]any
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		return nil, fmt.Errorf("unmarshaling header: %w", err)
+	}
+
+	return header, nil
+}

--- a/dpop/signer.go
+++ b/dpop/signer.go
@@ -1,0 +1,155 @@
+package dpop
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"maps"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+	"github.com/tink-crypto/tink-go/v2/signature/subtle"
+	"lds.li/oauth2ext/internal/th"
+)
+
+// Signer is used to sign DPoP proofs
+type Signer struct {
+	signer crypto.Signer
+	jwk    map[string]any
+}
+
+// NewSigner creates a new Signer using the provided [crypto.Signer].
+// The signer should represent a hardware bound or otherwise unextractable
+// signing key. The JWK will be calculated from the signer's public key.
+func NewSigner(signer crypto.Signer) (*Signer, error) {
+	jwk, err := publicKeyToJWK(signer.Public())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWK: %v", err)
+	}
+	return &Signer{
+		signer: signer,
+		jwk:    jwk,
+	}, nil
+}
+
+// SignAndEncode signs the JWT as a DPoP proof, and returns the compact JWT.
+func (e *Signer) SignAndEncode(raw *jwt.RawJWTOptions) (string, error) {
+	raw.TypeHeader = th.Ptr("dpop+jwt")
+	rawJWT, err := jwt.NewRawJWT(raw)
+	if err != nil {
+		return "", fmt.Errorf("creating raw JWT: %w", err)
+	}
+	return e.encodeWithHeaders(rawJWT, map[string]any{
+		"jwk": e.jwk,
+	})
+}
+
+// encodeWithHeaders encodes a JWT with additional custom headers. If a key
+// exists in both, the additionalHeaders value takes precedence.
+func (e *Signer) encodeWithHeaders(raw *jwt.RawJWT, additionalHeaders map[string]any) (string, error) {
+	payload, err := raw.JSONPayload()
+	if err != nil {
+		return "", fmt.Errorf("getting JSON payload: %w", err)
+	}
+
+	alg, err := e.determineAlgorithm()
+	if err != nil {
+		return "", fmt.Errorf("determining algorithm: %w", err)
+	}
+
+	header := map[string]any{
+		"alg": alg,
+	}
+
+	if raw.HasTypeHeader() {
+		typ, err := raw.TypeHeader()
+		if err == nil {
+			header["typ"] = typ
+		}
+	}
+
+	maps.Copy(header, additionalHeaders)
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("encoding header: %w", err)
+	}
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+
+	signingInput := headerB64 + "." + payloadB64
+
+	hasher, hashOpts, err := e.getHasher(alg)
+	if err != nil {
+		return "", fmt.Errorf("getting hasher: %w", err)
+	}
+
+	hasher.Write([]byte(signingInput))
+	hashed := hasher.Sum(nil)
+
+	signature, err := e.signer.Sign(rand.Reader, hashed, hashOpts)
+	if err != nil {
+		return "", fmt.Errorf("signing: %w", err)
+	}
+
+	if ecdsaKey, ok := e.signer.Public().(*ecdsa.PublicKey); ok {
+		// JWT uses IEEE P1363 format for ECDSA signatures but Go returns ASN.1
+		// DER format, so convert it.
+		tsig, err := subtle.DecodeECDSASignature(signature, "DER")
+		if err != nil {
+			return "", fmt.Errorf("decoding ECDSA signature: %w", err)
+		}
+		jwtsig, err := tsig.EncodeECDSASignature("IEEE_P1363", ecdsaKey.Curve.Params().Name)
+		if err != nil {
+			return "", fmt.Errorf("encoding ECDSA signature: %w", err)
+		}
+		signature = jwtsig
+	}
+
+	signatureB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	return signingInput + "." + signatureB64, nil
+}
+
+func (e *Signer) determineAlgorithm() (string, error) {
+	pubKey := e.signer.Public()
+
+	switch key := pubKey.(type) {
+	case *rsa.PublicKey:
+		// TODO - how best to support other algs? Add an opt?
+		return "RS256", nil
+	case *ecdsa.PublicKey:
+		switch key.Curve.Params().BitSize {
+		case 256:
+			return "ES256", nil
+		case 384:
+			return "ES384", nil
+		case 521:
+			return "ES512", nil
+		default:
+			return "", fmt.Errorf("unsupported ECDSA curve size: %d", key.Curve.Params().BitSize)
+		}
+	default:
+		return "", fmt.Errorf("unsupported public key type: %T", pubKey)
+	}
+}
+
+func (e *Signer) getHasher(alg string) (hash.Hash, crypto.SignerOpts, error) {
+	switch alg {
+	case "RS256", "ES256":
+		return sha256.New(), crypto.SHA256, nil
+	case "RS384", "ES384":
+		return sha512.New384(), crypto.SHA384, nil
+	case "RS512", "ES512":
+		return sha512.New(), crypto.SHA512, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported algorithm: %s", alg)
+	}
+}

--- a/dpop/verifier.go
+++ b/dpop/verifier.go
@@ -1,0 +1,189 @@
+package dpop
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"time"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+	"lds.li/oauth2ext/internal/th"
+)
+
+// DefaultValidityAfterIssue is the default validity after the issue time for a
+// DPoP token, if it has no explicit expiry.
+const DefaultValidityAfterIssue = 10 * time.Minute
+
+type Verifier struct {
+	// ValidityAfterIssue is the validity after the issue time for a DPoP token,
+	// if it has no explicit expiry. Defaults to DefaultValidityAfterIssue.
+	ValidityAfterIssue time.Duration
+
+	now time.Time
+}
+
+// Proof is the result of verifying a DPoP token.
+type Proof struct {
+	// VerifiedJWT is the verified JWT.
+	VerifiedJWT *jwt.VerifiedJWT
+	// Thumbprint is the JWK thumbprint.
+	Thumbprint string
+}
+
+// ValidatorOpts parameters for DPoP token validation.
+type ValidatorOpts struct {
+	// ExpectedThumbprint is the expected JWK thumbprint. The token must match
+	// this.
+	ExpectedThumbprint string
+	// IgnoreThumbprint is used to ignore the thumbprint check, this is useful
+	// for the initial validation before the thumbprint is bound to the token.
+	IgnoreThumbprint bool
+	// ExpectedHTM is the expected HTTP method. If set, the htm claim must match.
+	ExpectedHTM *string
+	// ExpectedHTU is the expected HTTP URI. If set, the htu claim must match.
+	ExpectedHTU *string
+	// AllowUnsetHTMHTU is used to allow the htm and htu claims to be unset. If
+	// this is true, the expected values will only be checked if the claims are
+	// set.
+	AllowUnsetHTMHTU bool
+}
+
+// Validator is used to validate DPoP tokens
+type Validator struct {
+	opts *ValidatorOpts
+}
+
+func NewValidator(opts *ValidatorOpts) (*Validator, error) {
+	return &Validator{
+		opts: opts,
+	}, nil
+}
+
+// VerifyAndDecode verifies a DPoP token and returns the verified JWT along with
+// the JWK thumbprint.
+func (d *Verifier) VerifyAndDecode(compact string, validator *Validator) (*Proof, error) {
+	header, err := parseJWTHeader(compact)
+	if err != nil {
+		return nil, fmt.Errorf("parsing JWT header: %w", err)
+	}
+
+	jwkRaw, ok := header["jwk"]
+	if !ok {
+		return nil, fmt.Errorf("jwk header is missing")
+	}
+
+	thumbprint, err := calculateJWKThumbprint(jwkRaw)
+	if err != nil {
+		return nil, fmt.Errorf("calculating JWK thumbprint: %w", err)
+	}
+
+	// Firstly, make sure the thumbprint matches the expected one. Can fail fase
+	// if it doesn't
+	if !validator.opts.IgnoreThumbprint && thumbprint != validator.opts.ExpectedThumbprint {
+		return nil, fmt.Errorf("JWK thumbprint mismatch: got %q, want %q", thumbprint, validator.opts.ExpectedThumbprint)
+	}
+
+	// we need to make sure we have an alg for the JWK, for tink to handle it.
+	// We rely on it to validate the specified alg matches the key type.
+	alg, ok := header["alg"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing or invalid alg in header")
+	}
+
+	jwkMap, ok := jwkRaw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("jwk is not a map")
+	}
+
+	jwkForTink := make(map[string]any)
+	maps.Copy(jwkForTink, jwkMap)
+	jwkForTink["alg"] = alg
+
+	jwkWithAlgJSON, err := json.Marshal(jwkForTink)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling jwk with alg: %w", err)
+	}
+
+	handle, err := jwt.JWKSetToPublicKeysetHandle(fmt.Appendf(nil, `{"keys":[%s]}`, string(jwkWithAlgJSON)))
+	if err != nil {
+		return nil, fmt.Errorf("creating keyset handle from JWK: %w", err)
+	}
+
+	verifier, err := jwt.NewVerifier(handle)
+	if err != nil {
+		return nil, fmt.Errorf("creating tink verifier: %w", err)
+	}
+
+	tinkValidator, err := jwt.NewValidator(&jwt.ValidatorOpts{
+		ExpectedTypeHeader:     th.Ptr("dpop+jwt"),
+		AllowMissingExpiration: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating validator: %w", err)
+	}
+
+	verifiedJWT, err := verifier.VerifyAndDecode(compact, tinkValidator)
+	if err != nil {
+		return nil, fmt.Errorf("verifying JWT: %w", err)
+	}
+
+	now := time.Now()
+	if !d.now.IsZero() {
+		now = d.now
+	}
+
+	if !verifiedJWT.HasExpiration() {
+		iat, err := verifiedJWT.IssuedAt()
+		if err != nil {
+			return nil, fmt.Errorf("getting issued at: %w", err)
+		}
+		vp := d.ValidityAfterIssue
+		if vp == 0 {
+			vp = DefaultValidityAfterIssue
+		}
+		if now.After(iat.Add(vp)) {
+			return nil, fmt.Errorf("token expired")
+		}
+	}
+
+	if validator.opts.ExpectedHTM != nil {
+		if !verifiedJWT.HasStringClaim("htm") {
+			if !validator.opts.AllowUnsetHTMHTU {
+				return nil, fmt.Errorf("htm claim missing")
+			}
+			// If AllowUnsetHTMHTU is true, we allow the claim to be missing
+		} else {
+			// Claim exists, so we must validate it matches
+			htm, err := verifiedJWT.StringClaim("htm")
+			if err != nil {
+				return nil, fmt.Errorf("getting htm claim: %w", err)
+			}
+			if htm != *validator.opts.ExpectedHTM {
+				return nil, fmt.Errorf("htm claim mismatch: got %q, want %q", htm, *validator.opts.ExpectedHTM)
+			}
+		}
+	}
+
+	if validator.opts.ExpectedHTU != nil {
+		if !verifiedJWT.HasStringClaim("htu") {
+			if !validator.opts.AllowUnsetHTMHTU {
+				return nil, fmt.Errorf("htu claim missing")
+			}
+			// If AllowUnsetHTMHTU is true, we allow the claim to be missing
+		} else {
+			// Claim exists, so we must validate it matches
+			htu, err := verifiedJWT.StringClaim("htu")
+			if err != nil {
+				return nil, fmt.Errorf("getting htu claim: %w", err)
+			}
+			if htu != *validator.opts.ExpectedHTU {
+				return nil, fmt.Errorf("htu claim mismatch: got %q, want %q", htu, *validator.opts.ExpectedHTU)
+			}
+		}
+	}
+
+	return &Proof{
+		VerifiedJWT: verifiedJWT,
+		Thumbprint:  thumbprint,
+	}, nil
+}

--- a/dpop/verifier_test.go
+++ b/dpop/verifier_test.go
@@ -1,0 +1,582 @@
+package dpop
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+)
+
+// Example DPoP token from RFC 9449 Appendix A.1
+// Header: {"typ":"dpop+jwt","alg":"ES256","jwk":{"kty":"EC","x":"l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfVWAWBFs","y":"9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA","crv":"P-256"}}
+// Claims: {"jti":"-BwC3ESc6acc2lTc","htm":"POST","htu":"https://server.example.com/token","iat":1562262616}
+// Note: This is an example token, but the signature may not be valid for the given JWK.
+// For a real test, we'd need to generate a token with a known private key.
+const rfc9449ExampleToken = "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCRnMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JEQSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiItQndDM0VTYzZhY2MybFRjIiwiaHRtIjoiUE9TVCIsImh0dSI6Imh0dHBzOi8vc2VydmVyLmV4YW1wbGUuY29tL3Rva2VuIiwiaWF0IjoxNTYyMjYyNjE2fQ.2-GxA6T8lP4vfrg8v-FdWP0A0zdrj8igiMLvqRMUvwnQg4PtFLbdLXiOSsX0x7NVY-FNyJK70nfbV37xRZT3Lg"
+
+func TestDPoPVerifier_ExampleToken(t *testing.T) {
+	// Try to verify the token
+	// Note: This example token may not have a valid signature, so we expect it might fail
+	dv := &Verifier{
+		// set our time to when the e.g token was made.
+		now: time.Unix(1562262616, 0).Add(10 * time.Minute),
+	}
+
+	// Extract thumbprint from the token header for validation
+	header, err := parseJWTHeader(rfc9449ExampleToken)
+	if err != nil {
+		t.Fatalf("failed to parse JWT header: %v", err)
+	}
+	jwkRaw, ok := header["jwk"]
+	if !ok {
+		t.Fatal("jwk header is missing")
+	}
+	expectedThumbprint, err := calculateJWKThumbprint(jwkRaw)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	validator, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: expectedThumbprint,
+	})
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	verifiedJWT, err := dv.VerifyAndDecode(rfc9449ExampleToken, validator)
+	if err != nil {
+		t.Fatalf("failed to verify and decode DPoP token: %v", err)
+	}
+
+	// If verification succeeds, check the results
+	if verifiedJWT == nil {
+		t.Error("VerifiedJWT is nil")
+	}
+
+	t.Logf("Successfully verified DPoP token with thumbprint: %s", expectedThumbprint)
+}
+
+// generateTestKey generates a test ECDSA P-256 key pair for testing.
+func generateTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ECDSA key: %v", err)
+	}
+	return privKey
+}
+
+func TestDPoPVerifier_RoundTrip(t *testing.T) {
+	// Generate a test ECDSA key
+	privKey := generateTestKey(t)
+
+	// Create signer using the constructor - it automatically creates the JWK
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("failed to create encoder: %v", err)
+	}
+
+	// Create DPoP token with typ header
+	// DPoP tokens typically don't have an explicit expiration - they use iat with
+	// a validity window, so we mark it WithoutExpiration
+	now := time.Now()
+	opts := &jwt.RawJWTOptions{
+		WithoutExpiration: true,
+		CustomClaims: map[string]any{
+			"htm": "POST",
+			"htu": "https://server.example.com/token",
+		},
+		IssuedAt: &now,
+	}
+
+	// SignAndEncode now automatically includes the jwk header
+	token, err := signer.SignAndEncode(opts)
+	if err != nil {
+		t.Fatalf("failed to encode DPoP token: %v", err)
+	}
+
+	// Calculate expected thumbprint from the encoder's JWK
+	expectedThumbprint, err := calculateJWKThumbprint(signer.jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate expected thumbprint: %v", err)
+	}
+
+	// Create validator with expected thumbprint
+	validator, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: expectedThumbprint,
+	})
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	// Verify using DPoPVerifier (which uses Tink internally)
+	verifier := &Verifier{}
+	verifiedJWT, err := verifier.VerifyAndDecode(token, validator)
+	if err != nil {
+		t.Fatalf("failed to verify and decode DPoP token: %v", err)
+	}
+
+	// Verify the JWT is not nil
+	if verifiedJWT == nil {
+		t.Error("verifiedJWT is nil")
+	}
+
+	t.Logf("Successfully completed DPoP round-trip with thumbprint: %s", expectedThumbprint)
+}
+
+func TestDPoPVerifier_RejectsMissingJWK(t *testing.T) {
+	// Create a token without the jwk header using encodeWithHeaders directly
+	privKey := generateTestKey(t)
+
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("failed to create encoder: %v", err)
+	}
+
+	now := time.Now()
+	opts := &jwt.RawJWTOptions{
+		TypeHeader:        stringPtr("dpop+jwt"),
+		WithoutExpiration: true,
+		IssuedAt:          &now,
+	}
+	rawJWT, err := jwt.NewRawJWT(opts)
+	if err != nil {
+		t.Fatalf("failed to create raw JWT: %v", err)
+	}
+
+	// Encode without jwk header by passing empty additionalHeaders
+	token, err := signer.encodeWithHeaders(rawJWT, nil)
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	// DPoPVerifier should reject tokens without jwk header
+	// We need to extract thumbprint from a valid token structure, but this token doesn't have jwk
+	// So we'll create a validator with an empty thumbprint - it should fail during header parsing
+	validator, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: "", // Will fail during verification
+	})
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	verifier := &Verifier{}
+	_, err = verifier.VerifyAndDecode(token, validator)
+	if err == nil {
+		t.Error("expected error for token without jwk header")
+	}
+	t.Logf("correctly rejected token without jwk: %v", err)
+}
+
+func TestDPoPVerifier_RejectsExpiredToken(t *testing.T) {
+	// Create a DPoP token that is expired (issued in the past beyond validity window)
+	privKey := generateTestKey(t)
+
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("failed to create encoder: %v", err)
+	}
+
+	// Issue token 20 minutes ago (default validity is 10 minutes)
+	issuedAt := time.Now().Add(-20 * time.Minute)
+	opts := &jwt.RawJWTOptions{
+		TypeHeader:        stringPtr("dpop+jwt"),
+		WithoutExpiration: true,
+		IssuedAt:          &issuedAt,
+		CustomClaims: map[string]any{
+			"htm": "POST",
+			"htu": "https://server.example.com/token",
+		},
+	}
+	token, err := signer.SignAndEncode(opts)
+	if err != nil {
+		t.Fatalf("failed to encode DPoP token: %v", err)
+	}
+
+	// Calculate thumbprint for validation
+	expectedThumbprint, err := calculateJWKThumbprint(signer.jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	validator, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: expectedThumbprint,
+	})
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	// DPoPVerifier should reject expired tokens
+	verifier := &Verifier{}
+	_, err = verifier.VerifyAndDecode(token, validator)
+	if err == nil {
+		t.Error("expected error for expired token")
+	}
+	t.Logf("correctly rejected expired token: %v", err)
+}
+
+func TestJWKThumbprint_Calculation(t *testing.T) {
+	// Test that thumbprint calculation works correctly
+	// The JWK from the RFC example:
+	jwk := map[string]any{
+		"kty": "EC",
+		"crv": "P-256",
+		"x":   "l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfVWAWBFs",
+		"y":   "9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA",
+	}
+
+	thumbprint, err := calculateJWKThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	if thumbprint == "" {
+		t.Error("thumbprint is empty")
+	}
+
+	// The thumbprint should be a base64url-encoded string (43 characters for SHA-256)
+	if len(thumbprint) != 43 {
+		t.Errorf("thumbprint has unexpected length: got %d, expected 43", len(thumbprint))
+	}
+
+	// Calculate again - should be the same
+	thumbprint2, err := calculateJWKThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint second time: %v", err)
+	}
+
+	if thumbprint != thumbprint2 {
+		t.Error("thumbprint calculation is not deterministic")
+	}
+
+	t.Logf("JWK thumbprint: %s", thumbprint)
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestDPoPVerifier_HTM_HTU_Validation(t *testing.T) {
+	privKey := generateTestKey(t)
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("failed to create encoder: %v", err)
+	}
+
+	now := time.Now()
+	opts := &jwt.RawJWTOptions{
+		WithoutExpiration: true,
+		CustomClaims: map[string]any{
+			"htm": "POST",
+			"htu": "https://server.example.com/token",
+		},
+		IssuedAt: &now,
+	}
+
+	token, err := signer.SignAndEncode(opts)
+	if err != nil {
+		t.Fatalf("failed to encode DPoP token: %v", err)
+	}
+
+	// Calculate thumbprint for validation
+	expectedThumbprint, err := calculateJWKThumbprint(signer.jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	htm := "POST"
+	htu := "https://server.example.com/token"
+
+	t.Run("Valid HTM and HTU", func(t *testing.T) {
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &htm,
+			ExpectedHTU:        &htu,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err != nil {
+			t.Fatalf("verification failed: %v", err)
+		}
+	})
+
+	t.Run("HTM mismatch", func(t *testing.T) {
+		wrongHTM := "GET"
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &wrongHTM,
+			ExpectedHTU:        &htu,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err == nil {
+			t.Fatal("expected error for HTM mismatch")
+		}
+		if !strings.Contains(err.Error(), "htm claim mismatch") {
+			t.Errorf("expected htm mismatch error, got: %v", err)
+		}
+	})
+
+	t.Run("HTU mismatch", func(t *testing.T) {
+		wrongHTU := "https://other.example.com/token"
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &htm,
+			ExpectedHTU:        &wrongHTU,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err == nil {
+			t.Fatal("expected error for HTU mismatch")
+		}
+		if !strings.Contains(err.Error(), "htu claim mismatch") {
+			t.Errorf("expected htu mismatch error, got: %v", err)
+		}
+	})
+
+	t.Run("No validation when options not provided", func(t *testing.T) {
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err != nil {
+			t.Fatalf("verification failed: %v", err)
+		}
+	})
+}
+
+func TestDPoPVerifier_AllowUnsetHTMHTU(t *testing.T) {
+	privKey := generateTestKey(t)
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("failed to create encoder: %v", err)
+	}
+
+	expectedThumbprint, err := calculateJWKThumbprint(signer.jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	htm := "POST"
+	htu := "https://server.example.com/token"
+
+	t.Run("AllowUnsetHTMHTU=false rejects missing htm", func(t *testing.T) {
+		// Create token without htm claim
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			WithoutExpiration: true,
+			CustomClaims: map[string]any{
+				"htu": htu,
+			},
+			IssuedAt: &now,
+		}
+		token, err := signer.SignAndEncode(opts)
+		if err != nil {
+			t.Fatalf("failed to encode DPoP token: %v", err)
+		}
+
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &htm,
+			AllowUnsetHTMHTU:   false,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err == nil {
+			t.Fatal("expected error for missing htm claim when AllowUnsetHTMHTU=false")
+		}
+		if !strings.Contains(err.Error(), "htm claim missing") {
+			t.Errorf("expected htm missing error, got: %v", err)
+		}
+	})
+
+	t.Run("AllowUnsetHTMHTU=false rejects missing htu", func(t *testing.T) {
+		// Create token without htu claim
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			WithoutExpiration: true,
+			CustomClaims: map[string]any{
+				"htm": htm,
+			},
+			IssuedAt: &now,
+		}
+		token, err := signer.SignAndEncode(opts)
+		if err != nil {
+			t.Fatalf("failed to encode DPoP token: %v", err)
+		}
+
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTU:        &htu,
+			AllowUnsetHTMHTU:   false,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err == nil {
+			t.Fatal("expected error for missing htu claim when AllowUnsetHTMHTU=false")
+		}
+		if !strings.Contains(err.Error(), "htu claim missing") {
+			t.Errorf("expected htu missing error, got: %v", err)
+		}
+	})
+
+	t.Run("AllowUnsetHTMHTU=true allows missing htm", func(t *testing.T) {
+		// Create token without htm claim
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			WithoutExpiration: true,
+			CustomClaims: map[string]any{
+				"htu": htu,
+			},
+			IssuedAt: &now,
+		}
+		token, err := signer.SignAndEncode(opts)
+		if err != nil {
+			t.Fatalf("failed to encode DPoP token: %v", err)
+		}
+
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &htm,
+			AllowUnsetHTMHTU:   true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err != nil {
+			t.Fatalf("verification should succeed with missing htm when AllowUnsetHTMHTU=true: %v", err)
+		}
+	})
+
+	t.Run("AllowUnsetHTMHTU=true allows missing htu", func(t *testing.T) {
+		// Create token without htu claim
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			WithoutExpiration: true,
+			CustomClaims: map[string]any{
+				"htm": htm,
+			},
+			IssuedAt: &now,
+		}
+		token, err := signer.SignAndEncode(opts)
+		if err != nil {
+			t.Fatalf("failed to encode DPoP token: %v", err)
+		}
+
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTU:        &htu,
+			AllowUnsetHTMHTU:   true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err != nil {
+			t.Fatalf("verification should succeed with missing htu when AllowUnsetHTMHTU=true: %v", err)
+		}
+	})
+
+	t.Run("AllowUnsetHTMHTU=true still validates when claims exist", func(t *testing.T) {
+		// Create token with both claims
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			WithoutExpiration: true,
+			CustomClaims: map[string]any{
+				"htm": htm,
+				"htu": htu,
+			},
+			IssuedAt: &now,
+		}
+		token, err := signer.SignAndEncode(opts)
+		if err != nil {
+			t.Fatalf("failed to encode DPoP token: %v", err)
+		}
+
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &htm,
+			ExpectedHTU:        &htu,
+			AllowUnsetHTMHTU:   true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err != nil {
+			t.Fatalf("verification should succeed with matching claims: %v", err)
+		}
+	})
+
+	t.Run("AllowUnsetHTMHTU=true still rejects mismatched claims", func(t *testing.T) {
+		// Create token with mismatched htm
+		now := time.Now()
+		opts := &jwt.RawJWTOptions{
+			WithoutExpiration: true,
+			CustomClaims: map[string]any{
+				"htm": "GET", // Different from expected
+				"htu": htu,
+			},
+			IssuedAt: &now,
+		}
+		token, err := signer.SignAndEncode(opts)
+		if err != nil {
+			t.Fatalf("failed to encode DPoP token: %v", err)
+		}
+
+		validator, err := NewValidator(&ValidatorOpts{
+			ExpectedThumbprint: expectedThumbprint,
+			ExpectedHTM:        &htm,
+			ExpectedHTU:        &htu,
+			AllowUnsetHTMHTU:   true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create validator: %v", err)
+		}
+
+		verifier := &Verifier{}
+		_, err = verifier.VerifyAndDecode(token, validator)
+		if err == nil {
+			t.Fatal("expected error for mismatched htm claim even when AllowUnsetHTMHTU=true")
+		}
+		if !strings.Contains(err.Error(), "htm claim mismatch") {
+			t.Errorf("expected htm mismatch error, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This adds support for encoding and decoding JWT's for DPoP. Where possible we lean on Tink, but we do need to do custom header parsing to get the proof JWKs, as it doesn't support custom headers. The encoding side is implemented here to allow opaque signing keys (e.g SEP), and to set the header appropriately.