### PR TITLE
dpop: HTTP Transport

### DIFF
--- a/dpop/transport.go
+++ b/dpop/transport.go
@@ -1,0 +1,51 @@
+package dpop
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/tink-crypto/tink-go/v2/jwt"
+)
+
+// Transport is an [http.RoundTripper] that adds DPoP headers to requests.
+type Transport struct {
+	// Signer is used to sign DPoP proofs
+	Signer *Signer
+
+	// Base is the underlying transport. If nil, http.DefaultTransport is used.
+	Base http.RoundTripper
+}
+
+// RoundTrip implements [http.RoundTripper] by adding a DPoP header to the
+// request and then calling the base transport.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Signer == nil {
+		return nil, fmt.Errorf("dpop: Signer is nil")
+	}
+
+	// Generate DPoP proof with htm and htu claims
+	now := time.Now()
+	proof, err := t.Signer.SignAndEncode(&jwt.RawJWTOptions{
+		WithoutExpiration: true,
+		IssuedAt:          &now,
+		CustomClaims: map[string]any{
+			"htm": req.Method,
+			"htu": req.URL.String(),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dpop: failed to create proof: %w", err)
+	}
+
+	// Clone the request to avoid modifying the original
+	req = req.Clone(req.Context())
+	req.Header.Set("DPoP", proof)
+
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	return base.RoundTrip(req)
+}

--- a/dpop/transport_test.go
+++ b/dpop/transport_test.go
@@ -1,0 +1,80 @@
+package dpop
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTransport(t *testing.T) {
+	privKey := generateTestKey(t)
+
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+
+	// TODO - we might want to expose the thumbprint from the encoder or
+	// something? Let's see how it plays out.
+
+	expectedThumbprint, err := calculateJWKThumbprint(signer.jwk)
+	if err != nil {
+		t.Fatalf("failed to calculate thumbprint: %v", err)
+	}
+
+	var capturedDPoP string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedDPoP = r.Header.Get("DPoP")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: &Transport{
+			Signer: signer,
+		},
+	}
+
+	resp, err := client.Get(server.URL + "/test/path")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+
+	if capturedDPoP == "" {
+		t.Fatal("DPoP header was not added to request")
+	}
+
+	validator, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: expectedThumbprint,
+	})
+	if err != nil {
+		t.Fatalf("failed to create validator: %v", err)
+	}
+
+	verifier := &Verifier{}
+	verifiedJWT, err := verifier.VerifyAndDecode(capturedDPoP, validator)
+	if err != nil {
+		t.Fatalf("failed to verify DPoP proof: %v", err)
+	}
+
+	if verifiedJWT == nil {
+		t.Error("verifiedJWT is nil")
+	}
+
+	t.Logf("Successfully verified DPoP proof with thumbprint: %s", expectedThumbprint)
+}
+
+func TestTransport_NilSigner(t *testing.T) {
+	transport := &Transport{}
+	req := httptest.NewRequest("GET", "http://example.com", nil)
+
+	_, err := transport.RoundTrip(req)
+	if err == nil {
+		t.Fatal("expected error with nil signer, got nil")
+	}
+}


### PR DESCRIPTION
This adds a http.RoundTripper, that can be used to add proofs to outgoing requests.

It is simple at the moment, at some point we can add customization options for skipping htu/htm claims to use in cases with slower signers etc.