### PR TITLE
clitoken: Add support for getting a DPoP signer

### DIFF
--- a/clitoken/signer.go
+++ b/clitoken/signer.go
@@ -1,0 +1,66 @@
+package clitoken
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"io"
+	"sync"
+)
+
+var (
+	// platformCache is registered by any platform specific caches, and should be
+	// preferred
+	platformSigners []func() (crypto.Signer, error)
+	// genericCaches is a list in preference order of non-platform specific caches
+	genericSigners = []func() (crypto.Signer, error){
+		func() (crypto.Signer, error) {
+			return &localSigner{}, nil
+		},
+	}
+)
+
+// BestPlatformSigner returns the most preferred available signer for the
+// platform and environment, to be used for signing DPoP proofs in CLI tools.
+func BestPlatformSigner() (crypto.Signer, error) {
+	for _, s := range append(platformSigners, genericSigners...) {
+		signer, err := s()
+		if err != nil {
+			continue
+		}
+		return signer, nil
+	}
+
+	return &localSigner{}, nil
+}
+
+var (
+	localSignerKey  crypto.Signer
+	localSignerOnce sync.Once
+)
+
+// localSigner is a fallback signer, that exists for the process lifetime only.
+type localSigner struct{}
+
+func (*localSigner) Public() crypto.PublicKey {
+	localSignerOnce.Do(func() {
+		var err error
+		localSignerKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			panic(err)
+		}
+	})
+	return localSignerKey.Public()
+}
+
+func (*localSigner) Sign(randrdr io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	localSignerOnce.Do(func() {
+		var err error
+		localSignerKey, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			panic(err)
+		}
+	})
+	return localSignerKey.Sign(randrdr, digest, opts)
+}

--- a/clitoken/signer_darwin.go
+++ b/clitoken/signer_darwin.go
@@ -1,0 +1,73 @@
+//go:build darwin && cgo
+
+package clitoken
+
+import (
+	"crypto"
+	"errors"
+	"io"
+	"runtime"
+
+	"lds.li/oauth2ext/internal/keychain"
+)
+
+const sepSignerLabel = "oauth2ext-cli-sep"
+
+func init() {
+	platformSigners = append(platformSigners, newDarwinSEPSigner)
+}
+
+type darwinSEPSigner struct {
+	identity *keychain.CTKIdentity
+	signer   crypto.Signer
+}
+
+var _ crypto.Signer = &darwinSEPSigner{}
+
+func newDarwinSEPSigner() (crypto.Signer, error) {
+	identity, err := keychain.GetCTKIdentity(sepSignerLabel, nil)
+	if err != nil {
+		var kcErr *keychain.Error
+		if !errors.As(err, &kcErr) || kcErr.Code != keychain.KeychainErrorCodeItemNotFound {
+			return nil, err
+		}
+
+		// Identity doesn't exist, create it
+		_, err = keychain.CreateCTKIdentity(sepSignerLabel, keychain.CTKKeyTypeP256)
+		if err != nil {
+			return nil, err
+		}
+
+		// Get the identity with signing capability
+		identity, err = keychain.GetCTKIdentity(sepSignerLabel, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Get the signer from the identity
+	signer, err := identity.Signer()
+	if err != nil {
+		identity.Close()
+		return nil, err
+	}
+
+	dss := &darwinSEPSigner{
+		identity: identity,
+		signer:   signer,
+	}
+
+	runtime.AddCleanup(dss, func(identity *keychain.CTKIdentity) {
+		identity.Close()
+	}, identity)
+
+	return dss, nil
+}
+
+func (d *darwinSEPSigner) Public() crypto.PublicKey {
+	return d.signer.Public()
+}
+
+func (d *darwinSEPSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	return d.signer.Sign(rand, digest, opts)
+}


### PR DESCRIPTION
First place I want to use DPoP is CLI tool refresh tokens, so expose a way to get a signer without exposing the internal keychain package. This is done in a similar way to the credential cache.

Likely going to re-work the BestSigner/Cache setup at some point to allow for easier external implemetations, but for now this will do.