### PR TITLE
Clients return secrets by default

### DIFF
--- a/oauth2as/client.go
+++ b/oauth2as/client.go
@@ -31,10 +31,9 @@ func ClientOptSigningAlg(alg string) ClientOpt {
 type ClientSource interface {
 	// IsValidClientID should return true if the passed client ID is valid
 	IsValidClientID(_ context.Context, clientID string) (ok bool, err error)
-	// ValidateClientSecret should confirm if the passed secret is valid for the
-	// given client. If no secret is provided, clientSecret will be empty but
-	// this will still be called.
-	ValidateClientSecret(_ context.Context, clientID, clientSecret string) (ok bool, err error)
+	// ClientSecrets should return the list of valid client secrets for the
+	// given client.
+	ClientSecrets(_ context.Context, clientID string) ([]string, error)
 	// ValidateRedirectURI should return the list of valid redirect URIs. They
 	// will be compared for an exact match, with the exception of loopback
 	// addresses, which can have a variable port

--- a/oauth2as/e2e_test.go
+++ b/oauth2as/e2e_test.go
@@ -302,6 +302,15 @@ func (c staticClientSource) ValidateClientSecret(ctx context.Context, clientID, 
 	}), nil
 }
 
+func (c staticClientSource) ClientSecrets(ctx context.Context, clientID string) ([]string, error) {
+	for _, sc := range c {
+		if sc.ID == clientID {
+			return sc.Secrets, nil
+		}
+	}
+	return nil, fmt.Errorf("client not found")
+}
+
 func (c staticClientSource) RedirectURIs(ctx context.Context, clientID string) ([]string, error) {
 	for _, sc := range c {
 		if sc.ID == clientID {

--- a/oauth2as/server_test.go
+++ b/oauth2as/server_test.go
@@ -705,6 +705,15 @@ func (c staticClientSource) ValidateClientSecret(ctx context.Context, clientID, 
 	}), nil
 }
 
+func (c staticClientSource) ClientSecrets(ctx context.Context, clientID string) ([]string, error) {
+	for _, sc := range c {
+		if sc.ID == clientID {
+			return sc.Secrets, nil
+		}
+	}
+	return nil, fmt.Errorf("client not found")
+}
+
 func (c staticClientSource) RedirectURIs(ctx context.Context, clientID string) ([]string, error) {
 	for _, sc := range c {
 		if sc.ID == clientID {


### PR DESCRIPTION
Rather than having the client interface do the secret validation, we just have it return them. That allows us to make sure they are validated OK.

We will still want a custom verification method, but that should be an exception rather than the default. We also want to consider other things, like how JWT client authentication should be handled.