### PR TITLE
tpmsecrets: New module for TPM protected secret cache + signing

### DIFF
--- a/.github/workflows/tpm-tests-windows.yml
+++ b/.github/workflows/tpm-tests-windows.yml
@@ -1,0 +1,22 @@
+name: TPM Tests Windows
+on: [push]
+jobs:
+  tpm-tests-windows:
+    name: TPM E2E Tests (Windows)
+    runs-on: windows-latest
+    env:
+      GOTOOLCHAIN: local
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    # TODO - this at least makes sure it compiles, but the actions runner
+    # doesn't have a TPM. Would be nice to have one that does.
+    - name: Test tpmsecrets
+      working-directory: ./tpmsecrets
+      run: go test -v ./...

--- a/.github/workflows/tpm-tests.yml
+++ b/.github/workflows/tpm-tests.yml
@@ -1,0 +1,25 @@
+name: TPM Tests
+on: [push]
+jobs:
+  tpm-tests:
+    name: TPM E2E Tests
+    runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: local
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Install swtpm
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y swtpm
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    - name: Test tpmsecrets
+      working-directory: ./tpmsecrets
+      run: go test -v ./...

--- a/clitoken/cache.go
+++ b/clitoken/cache.go
@@ -21,6 +21,13 @@ var (
 	genericCaches = []tokencache.CredentialCache{&KeychainCLICredentialCache{}, &NullCredentialCache{}}
 )
 
+// RegisterCredentialCache registers a credential cache. This is intended to be
+// called by platform specific packages (e.g. tpmsecrets) in their init
+// functions.
+func RegisterCredentialCache(c tokencache.CredentialCache) {
+	platformCaches = append([]tokencache.CredentialCache{c}, platformCaches...)
+}
+
 type PassphrasePromptFunc func(prompt string) (passphrase string, err error)
 
 // BestCredentialCache returns the most preferred available credential client

--- a/clitoken/signer.go
+++ b/clitoken/signer.go
@@ -21,6 +21,12 @@ var (
 	}
 )
 
+// RegisterPlatformSigner registers a signer. This is intended to be called by
+// platform specific packages (e.g. tpmsecrets) in their init functions.
+func RegisterPlatformSigner(f func() (crypto.Signer, error)) {
+	platformSigners = append([]func() (crypto.Signer, error){f}, platformSigners...)
+}
+
 // BestPlatformSigner returns the most preferred available signer for the
 // platform and environment, to be used for signing DPoP proofs in CLI tools.
 func BestPlatformSigner() (crypto.Signer, error) {

--- a/tpmsecrets/aead.go
+++ b/tpmsecrets/aead.go
@@ -1,0 +1,130 @@
+package tpmsecrets
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/tink-crypto/tink-go/v2/tink"
+)
+
+// tpmAEAD implements tink.AEAD using TPM sealing.
+// It treats the TPM as a KMS that seals data (keys) to the machine.
+type tpmAEAD struct{}
+
+var _ tink.AEAD = (*tpmAEAD)(nil)
+
+type sealedBlob struct {
+	Public  []byte
+	Private []byte
+}
+
+func (t *tpmAEAD) Encrypt(plaintext, associatedData []byte) ([]byte, error) {
+	// For KMSEnvelope usage, AAD is typically empty for the DEK encryption.
+	// We ignore it anyway, as they TPM does not support arbitrary AAD binding.
+
+	rwc, err := openTPM()
+	if err != nil {
+		return nil, err
+	}
+	defer closeTPM(rwc)
+
+	srk, err := getSRK(rwc)
+	if err != nil {
+		return nil, err
+	}
+	defer flushHandle(rwc, srk.Handle)
+
+	// Create a KeyedHash object containing the data
+	create := tpm2.Create{
+		ParentHandle: *srk,
+		InSensitive: tpm2.TPM2BSensitiveCreate{
+			Sensitive: &tpm2.TPMSSensitiveCreate{
+				UserAuth: tpm2.TPM2BAuth{},
+				Data:     tpm2.NewTPMUSensitiveCreate(&tpm2.TPM2BSensitiveData{Buffer: plaintext}),
+			},
+		},
+		InPublic: tpm2.New2B(tpm2.TPMTPublic{
+			Type:    tpm2.TPMAlgKeyedHash,
+			NameAlg: tpm2.TPMAlgSHA256,
+			ObjectAttributes: tpm2.TPMAObject{
+				FixedTPM:            true,
+				FixedParent:         true,
+				SensitiveDataOrigin: false, // We provide the data
+				UserWithAuth:        true,
+				NoDA:                true,
+			},
+			Parameters: tpm2.NewTPMUPublicParms(tpm2.TPMAlgKeyedHash,
+				&tpm2.TPMSKeyedHashParms{
+					Scheme: tpm2.TPMTKeyedHashScheme{
+						Scheme: tpm2.TPMAlgNull,
+					},
+				},
+			),
+			Unique: tpm2.NewTPMUPublicID(tpm2.TPMAlgKeyedHash, &tpm2.TPM2BDigest{}),
+		}),
+	}
+
+	rsp, err := create.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm create: %w", err)
+	}
+
+	pubBytes := tpm2.Marshal(rsp.OutPublic)
+
+	blob := sealedBlob{
+		Private: rsp.OutPrivate.Buffer,
+		Public:  pubBytes,
+	}
+
+	return json.Marshal(blob)
+}
+
+func (t *tpmAEAD) Decrypt(ciphertext, associatedData []byte) ([]byte, error) {
+	var blob sealedBlob
+	if err := json.Unmarshal(ciphertext, &blob); err != nil {
+		return nil, fmt.Errorf("unmarshal sealed data: %w", err)
+	}
+
+	rwc, err := openTPM()
+	if err != nil {
+		return nil, err
+	}
+	defer closeTPM(rwc)
+
+	srk, err := getSRK(rwc)
+	if err != nil {
+		return nil, err
+	}
+	defer flushHandle(rwc, srk.Handle)
+
+	pub, err := tpm2.Unmarshal[tpm2.TPM2BPublic](blob.Public)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal public: %w", err)
+	}
+
+	load := tpm2.Load{
+		ParentHandle: *srk,
+		InPrivate:    tpm2.TPM2BPrivate{Buffer: blob.Private},
+		InPublic:     *pub,
+	}
+	loadRsp, err := load.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm load: %w", err)
+	}
+	defer flushHandle(rwc, loadRsp.ObjectHandle)
+
+	unseal := tpm2.Unseal{
+		ItemHandle: tpm2.AuthHandle{
+			Handle: loadRsp.ObjectHandle,
+			Name:   loadRsp.Name,
+			Auth:   tpm2.PasswordAuth(nil),
+		},
+	}
+	rsp, err := unseal.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm unseal: %w", err)
+	}
+
+	return rsp.OutData.Buffer, nil
+}

--- a/tpmsecrets/auto/auto.go
+++ b/tpmsecrets/auto/auto.go
@@ -1,0 +1,32 @@
+package auto
+
+import (
+	"crypto"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"lds.li/oauth2ext/clitoken"
+	"lds.li/oauth2ext/tpmsecrets"
+)
+
+func init() {
+	// Register the TPM implementation.
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		// Fallback or ignore
+		return
+	}
+	tpmDir := filepath.Join(cacheDir, "lds-oauth2ext-tpm")
+
+	clitoken.RegisterPlatformSigner(func() (crypto.Signer, error) {
+		s := &tpmsecrets.TPMSigner{Dir: tpmDir}
+		if !tpmsecrets.IsTPMAvailable() {
+			return nil, fmt.Errorf("TPM not available")
+		}
+		return s, nil
+	})
+
+	clitoken.RegisterCredentialCache(&tpmsecrets.TPMCredentialCache{Dir: tpmDir})
+}

--- a/tpmsecrets/cache.go
+++ b/tpmsecrets/cache.go
@@ -1,0 +1,107 @@
+package tpmsecrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tink-crypto/tink-go/v2/aead"
+	"github.com/tink-crypto/tink-go/v2/tink"
+	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/oidc"
+)
+
+// TPMCredentialCache implements tokencache.CredentialCache using TPM sealing via Tink KMS Envelope.
+type TPMCredentialCache struct {
+	Dir string
+}
+
+func (c *TPMCredentialCache) Available() bool {
+	rwc, err := openTPM()
+	if err == nil {
+		closeTPM(rwc)
+		return true
+	}
+	return false
+}
+
+func (c *TPMCredentialCache) getAEAD() tink.AEAD {
+	// Create the KEK AEAD backed by TPM
+	kekAEAD := &tpmAEAD{}
+
+	// Create the Envelope AEAD
+	// We use AES256GCM for the DEK
+	dekTemplate := aead.AES256GCMKeyTemplate()
+	return aead.NewKMSEnvelopeAEAD2(dekTemplate, kekAEAD)
+}
+
+func (c *TPMCredentialCache) Get(issuer, key string) (*oauth2.Token, error) {
+	dataPath := filepath.Join(c.Dir, cacheDataFile)
+	encData, err := readBlob(dataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	envAEAD := c.getAEAD()
+
+	plaintext, err := envAEAD.Decrypt(encData, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt failed: %w", err)
+	}
+
+	// Parse
+	var tokens map[string]*oidc.TokenWithID
+	if err := json.Unmarshal(plaintext, &tokens); err != nil {
+		return nil, fmt.Errorf("json unmarshal: %w", err)
+	}
+
+	cacheKey := c.cacheKey(issuer, key)
+	if t, ok := tokens[cacheKey]; ok {
+		return t.Token, nil
+	}
+
+	return nil, nil
+}
+
+func (c *TPMCredentialCache) Set(issuer, key string, token *oauth2.Token) error {
+	envAEAD := c.getAEAD()
+
+	// Read existing data to merge
+	var tokens map[string]*oidc.TokenWithID
+	dataPath := filepath.Join(c.Dir, cacheDataFile)
+	encData, err := readBlob(dataPath)
+	if err == nil {
+		if plaintext, err := envAEAD.Decrypt(encData, nil); err == nil {
+			if err := json.Unmarshal(plaintext, &tokens); err != nil {
+				// assume it's empty
+				tokens = nil
+			}
+		}
+	}
+	if tokens == nil {
+		tokens = make(map[string]*oidc.TokenWithID)
+	}
+
+	// Update
+	tokens[c.cacheKey(issuer, key)] = &oidc.TokenWithID{Token: token}
+
+	newData, err := json.Marshal(tokens)
+	if err != nil {
+		return err
+	}
+
+	ciphertext, err := envAEAD.Encrypt(newData, nil)
+	if err != nil {
+		return err
+	}
+
+	return writeBlob(dataPath, ciphertext)
+}
+
+func (c *TPMCredentialCache) cacheKey(issuer, key string) string {
+	return fmt.Sprintf("%s;%s", issuer, key)
+}

--- a/tpmsecrets/common.go
+++ b/tpmsecrets/common.go
@@ -1,0 +1,115 @@
+package tpmsecrets
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/transport"
+)
+
+const (
+	signerKeyFile = "tpm_signer_key.blob"
+	cacheDataFile = "tpm_cache_data.enc"
+)
+
+func IsTPMAvailable() bool {
+	_, err := openTPM()
+	return err == nil
+}
+
+func openTPM() (transport.TPM, error) {
+	if socket := os.Getenv("TPM_TEST_SOCKET"); socket != "" {
+		conn, err := net.Dial("tcp", socket)
+		if err != nil {
+			return nil, err
+		}
+		return transport.FromReadWriteCloser(conn), nil
+	}
+	return openPlatformTPM()
+}
+
+func closeTPM(t transport.TPM) {
+	if c, ok := t.(io.Closer); ok {
+		c.Close()
+	}
+}
+
+// getSRK creates a primary key (SRK) in the owner hierarchy.
+func getSRK(rwc transport.TPM) (*tpm2.AuthHandle, error) {
+	srk := tpm2.CreatePrimary{
+		PrimaryHandle: tpm2.TPMRHOwner,
+		InSensitive: tpm2.TPM2BSensitiveCreate{
+			Sensitive: &tpm2.TPMSSensitiveCreate{
+				UserAuth: tpm2.TPM2BAuth{},
+			},
+		},
+		InPublic: tpm2.New2B(tpm2.TPMTPublic{
+			Type:    tpm2.TPMAlgECC,
+			NameAlg: tpm2.TPMAlgSHA256,
+			ObjectAttributes: tpm2.TPMAObject{
+				FixedTPM:            true,
+				FixedParent:         true,
+				SensitiveDataOrigin: true,
+				UserWithAuth:        true,
+				NoDA:                true,
+				Restricted:          true,
+				Decrypt:             true,
+			},
+			Parameters: tpm2.NewTPMUPublicParms(tpm2.TPMAlgECC,
+				&tpm2.TPMSECCParms{
+					Symmetric: tpm2.TPMTSymDefObject{
+						Algorithm: tpm2.TPMAlgAES,
+						KeyBits:   tpm2.NewTPMUSymKeyBits(tpm2.TPMAlgAES, tpm2.TPMKeyBits(128)),
+						Mode:      tpm2.NewTPMUSymMode(tpm2.TPMAlgAES, tpm2.TPMAlgCFB),
+					},
+					Scheme: tpm2.TPMTECCScheme{
+						Scheme: tpm2.TPMAlgNull,
+					},
+					CurveID: tpm2.TPMECCNistP256,
+					KDF: tpm2.TPMTKDFScheme{
+						Scheme: tpm2.TPMAlgNull,
+					},
+				},
+			),
+			Unique: tpm2.NewTPMUPublicID(tpm2.TPMAlgECC, &tpm2.TPMSECCPoint{}),
+		}),
+	}
+
+	rsp, err := srk.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("creating primary: %w", err)
+	}
+
+	return &tpm2.AuthHandle{
+		Handle: rsp.ObjectHandle,
+		Name:   rsp.Name,
+		Auth:   tpm2.PasswordAuth(nil),
+	}, nil
+}
+
+// flushHandle is a helper to flush a handle and ignore errors (defer usage)
+func flushHandle(rwc transport.TPM, handle tpm2.TPMHandle) {
+	_, _ = tpm2.FlushContext{FlushHandle: handle}.Execute(rwc)
+}
+
+// readBlob reads a file into a byte slice.
+func readBlob(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(f)
+}
+
+// writeBlob writes a byte slice to a file.
+func writeBlob(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}

--- a/tpmsecrets/doc.go
+++ b/tpmsecrets/doc.go
@@ -1,0 +1,6 @@
+// Package tpmsecrets provides a TPM-based implementation of the
+// tokencache.CredentialCache interface, along with a crypto.Signer for signing
+// DPoP proofs.
+//
+// NOTE: This package is currently experimental and may change significantly.
+package tpmsecrets

--- a/tpmsecrets/e2e_test.go
+++ b/tpmsecrets/e2e_test.go
@@ -1,0 +1,166 @@
+package tpmsecrets
+
+import (
+	"crypto/rand"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+func TestE2E(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		swtpmPath, err := exec.LookPath("swtpm")
+		if err != nil {
+			t.Skip("swtpm not found, skipping E2E test")
+		}
+
+		// Create temp dir for state
+		tmpDir := t.TempDir()
+		tpmStateDir := filepath.Join(tmpDir, "tpm-state")
+		if err := os.Mkdir(tpmStateDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		// Pick a random port
+		// This is slightly racey but fine for local tests
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		port := l.Addr().(*net.TCPAddr).Port
+		l.Close()
+		addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+		// Start swtpm
+		// swtpm socket --tpm2 --server type=tcp,port=<port> --ctrl type=tcp,port=<ctrl-port> --tpmstate dir=<dir> --flags not-need-init,startup-clear
+		// We use --flags startup-clear so we don't need to send TPM2_Startup manually (though we could).
+		cmd := exec.Command(swtpmPath, "socket",
+			"--tpm2",
+			"--server", fmt.Sprintf("type=tcp,port=%d", port),
+			"--ctrl", fmt.Sprintf("type=tcp,port=%d", port+1), // Just need a ctrl port, unused
+			"--tpmstate", fmt.Sprintf("dir=%s", tpmStateDir),
+			"--flags", "not-need-init,startup-clear",
+		)
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}()
+
+		// Wait for socket
+		if !waitForPort(addr, 5*time.Second) {
+			t.Fatalf("swtpm did not come up on %s", addr)
+		}
+
+		// Set env
+		t.Setenv("TPM_TEST_SOCKET", addr)
+	} else {
+		// On Windows, try to use system TPM
+		tpm, err := openTPM()
+		if err != nil {
+			t.Skipf("System TPM not available: %v", err)
+		}
+		closeTPM(tpm)
+	}
+
+	tmpDir := t.TempDir()
+
+	// Run Tests
+	t.Run("Signer", func(t *testing.T) {
+		signerDir := filepath.Join(tmpDir, "signer")
+		if err := os.Mkdir(signerDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		s := &TPMSigner{Dir: signerDir}
+
+		// 1. Generate (implicitly via Public)
+		pub := s.Public()
+		if pub == nil {
+			t.Fatal("Public() returned nil")
+		}
+
+		// 2. Sign
+		hash := []byte("01234567890123456789012345678901") // 32 bytes
+		sig, err := s.Sign(rand.Reader, hash, nil)
+		if err != nil {
+			t.Fatalf("Sign failed: %v", err)
+		}
+		if len(sig) == 0 {
+			t.Fatal("Signature empty")
+		}
+
+		// 3. Verify? We trust the signer for now.
+	})
+
+	t.Run("Cache", func(t *testing.T) {
+		cacheDir := filepath.Join(tmpDir, "cache")
+		if err := os.Mkdir(cacheDir, 0700); err != nil {
+			t.Fatal(err)
+		}
+
+		c := &TPMCredentialCache{Dir: cacheDir}
+
+		if !c.Available() {
+			t.Fatal("Cache not available")
+		}
+
+		token := &oauth2.Token{
+			AccessToken: "test-access-token",
+			TokenType:   "Bearer",
+		}
+
+		// Set
+		if err := c.Set("https://issuer.com", "client-id", token); err != nil {
+			t.Fatalf("Set failed: %v", err)
+		}
+
+		// Get
+		got, err := c.Get("https://issuer.com", "client-id")
+		if err != nil {
+			t.Fatalf("Get failed: %v", err)
+		}
+		if got == nil {
+			t.Fatal("Get returned nil")
+		}
+		if got.AccessToken != "test-access-token" {
+			t.Errorf("Got token %q, want %q", got.AccessToken, "test-access-token")
+		}
+
+		// Verify persistence by recreating cache
+		c2 := &TPMCredentialCache{Dir: cacheDir}
+		got2, err := c2.Get("https://issuer.com", "client-id")
+		if err != nil {
+			t.Fatalf("Get2 failed: %v", err)
+		}
+		if got2 == nil {
+			t.Fatal("Get2 returned nil")
+		}
+		if got2.AccessToken != "test-access-token" {
+			t.Errorf("Got2 token %q, want %q", got2.AccessToken, "test-access-token")
+		}
+	})
+}
+
+func waitForPort(addr string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.Dial("tcp", addr)
+		if err == nil {
+			conn.Close()
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return false
+}

--- a/tpmsecrets/go.mod
+++ b/tpmsecrets/go.mod
@@ -1,0 +1,18 @@
+module lds.li/oauth2ext/tpmsecrets
+
+go 1.25
+
+replace lds.li/oauth2ext => ../
+
+require (
+	github.com/google/go-tpm v0.9.3
+	golang.org/x/oauth2 v0.34.0
+	lds.li/oauth2ext v0.0.0-00010101000000-000000000000
+)
+
+require (
+	github.com/tink-crypto/tink-go/v2 v2.6.0 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	google.golang.org/protobuf v1.36.11 // indirect
+)

--- a/tpmsecrets/go.sum
+++ b/tpmsecrets/go.sum
@@ -1,0 +1,16 @@
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-tpm v0.9.3 h1:+yx0/anQuGzi+ssRqeD6WpXjW2L/V0dItUayO0i9sRc=
+github.com/google/go-tpm v0.9.3/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
+github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba h1:qJEJcuLzH5KDR0gKc0zcktin6KSAwL7+jWKBYceddTc=
+github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:EFYHy8/1y2KfgTAsx7Luu7NGhoxtuVHnNo8jE7FikKc=
+github.com/tink-crypto/tink-go/v2 v2.6.0 h1:+KHNBHhWH33Vn+igZWcsgdEPUxKwBMEe0QC60t388v4=
+github.com/tink-crypto/tink-go/v2 v2.6.0/go.mod h1:2WbBA6pfNsAfBwDCggboaHeB2X29wkU8XHtGwh2YIk8=
+golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
+golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
+golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
+golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/tpmsecrets/open_nix.go
+++ b/tpmsecrets/open_nix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package tpmsecrets
+
+import (
+	"os"
+
+	"github.com/google/go-tpm/tpm2/transport"
+	"github.com/google/go-tpm/tpm2/transport/linuxtpm"
+)
+
+const (
+	tpmDevicePath         = "/dev/tpmrm0"
+	fallbackTpmDevicePath = "/dev/tpm0"
+)
+
+func openPlatformTPM() (transport.TPM, error) {
+	if _, err := os.Stat(tpmDevicePath); err == nil {
+		return linuxtpm.Open(tpmDevicePath)
+	}
+	return linuxtpm.Open(fallbackTpmDevicePath)
+}

--- a/tpmsecrets/open_windows.go
+++ b/tpmsecrets/open_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tpmsecrets
+
+import (
+	"github.com/google/go-tpm/tpm2/transport"
+	"github.com/google/go-tpm/tpm2/transport/windowstpm"
+)
+
+func openPlatformTPM() (transport.TPM, error) {
+	return windowstpm.Open()
+}

--- a/tpmsecrets/signer.go
+++ b/tpmsecrets/signer.go
@@ -1,0 +1,281 @@
+package tpmsecrets
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/asn1"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/big"
+	"path/filepath"
+	"sync"
+
+	"github.com/google/go-tpm/tpm2"
+	"github.com/google/go-tpm/tpm2/transport"
+)
+
+type TPMSigner struct {
+	Dir string
+
+	mu        sync.Mutex
+	publicKey crypto.PublicKey
+}
+
+func (s *TPMSigner) Public() crypto.PublicKey {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.publicKey != nil {
+		return s.publicKey
+	}
+
+	rwc, err := openTPM()
+	if err != nil {
+		return nil
+	}
+	defer closeTPM(rwc)
+
+	keyHandle, err := s.loadKey(rwc)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			keyHandle, err = s.generateKey(rwc)
+			if err != nil {
+				return nil
+			}
+		} else {
+			return nil
+		}
+	}
+	defer flushHandle(rwc, keyHandle.Handle)
+
+	pub, err := getKeyPublic(rwc, keyHandle.Handle)
+	if err != nil {
+		return nil
+	}
+	s.publicKey = pub
+	return pub
+}
+
+func (s *TPMSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rwc, err := openTPM()
+	if err != nil {
+		return nil, err
+	}
+	defer closeTPM(rwc)
+
+	keyHandle, err := s.loadKey(rwc)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			keyHandle, err = s.generateKey(rwc)
+			if err != nil {
+				return nil, fmt.Errorf("generating key: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("loading key: %w", err)
+		}
+	}
+	defer flushHandle(rwc, keyHandle.Handle)
+
+	// Sign
+	sign := tpm2.Sign{
+		KeyHandle: *keyHandle,
+		Digest: tpm2.TPM2BDigest{
+			Buffer: digest,
+		},
+		InScheme: tpm2.TPMTSigScheme{
+			Scheme: tpm2.TPMAlgECDSA,
+			Details: tpm2.NewTPMUSigScheme(tpm2.TPMAlgECDSA, &tpm2.TPMSSchemeHash{
+				HashAlg: tpm2.TPMAlgSHA256,
+			}),
+		},
+		Validation: tpm2.TPMTTKHashCheck{
+			Tag: tpm2.TPMSTHashCheck,
+		},
+	}
+
+	rsp, err := sign.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm sign: %w", err)
+	}
+
+	eccSig, err := rsp.Signature.Signature.ECDSA()
+	if err != nil {
+		return nil, fmt.Errorf("getting ecdsa signature: %w", err)
+	}
+
+	r := big.NewInt(0).SetBytes(eccSig.SignatureR.Buffer)
+	sVal := big.NewInt(0).SetBytes(eccSig.SignatureS.Buffer)
+
+	return asn1.Marshal(struct{ R, S *big.Int }{r, sVal})
+}
+
+// loadKey loads the key from disk and into the TPM. Returns handle.
+func (s *TPMSigner) loadKey(rwc transport.TPM) (*tpm2.AuthHandle, error) {
+	path := filepath.Join(s.Dir, signerKeyFile)
+	data, err := readBlob(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var blob struct {
+		Private []byte
+		Public  []byte
+	}
+	if err := json.Unmarshal(data, &blob); err != nil {
+		return nil, fmt.Errorf("unmarshal key: %w", err)
+	}
+
+	srk, err := getSRK(rwc)
+	if err != nil {
+		return nil, err
+	}
+	defer flushHandle(rwc, srk.Handle)
+
+	pub, err := tpm2.Unmarshal[tpm2.TPM2BPublic](blob.Public)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal public: %w", err)
+	}
+
+	load := tpm2.Load{
+		ParentHandle: *srk,
+		InPrivate:    tpm2.TPM2BPrivate{Buffer: blob.Private},
+		InPublic:     *pub,
+	}
+
+	loadRsp, err := load.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm load: %w", err)
+	}
+
+	return &tpm2.AuthHandle{
+		Handle: loadRsp.ObjectHandle,
+		Name:   loadRsp.Name,
+		Auth:   tpm2.PasswordAuth(nil),
+	}, nil
+}
+
+func (s *TPMSigner) generateKey(rwc transport.TPM) (*tpm2.AuthHandle, error) {
+	srk, err := getSRK(rwc)
+	if err != nil {
+		return nil, err
+	}
+	defer flushHandle(rwc, srk.Handle)
+
+	create := tpm2.Create{
+		ParentHandle: *srk,
+		InSensitive: tpm2.TPM2BSensitiveCreate{
+			Sensitive: &tpm2.TPMSSensitiveCreate{
+				UserAuth: tpm2.TPM2BAuth{},
+			},
+		},
+		InPublic: tpm2.New2B(tpm2.TPMTPublic{
+			Type:    tpm2.TPMAlgECC,
+			NameAlg: tpm2.TPMAlgSHA256,
+			ObjectAttributes: tpm2.TPMAObject{
+				FixedTPM:            true,
+				FixedParent:         true,
+				SensitiveDataOrigin: true,
+				UserWithAuth:        true,
+				SignEncrypt:         true,
+			},
+			Parameters: tpm2.NewTPMUPublicParms(tpm2.TPMAlgECC,
+				&tpm2.TPMSECCParms{
+					Symmetric: tpm2.TPMTSymDefObject{
+						Algorithm: tpm2.TPMAlgNull,
+					},
+					Scheme: tpm2.TPMTECCScheme{
+						Scheme: tpm2.TPMAlgECDSA,
+						Details: tpm2.NewTPMUAsymScheme(tpm2.TPMAlgECDSA,
+							&tpm2.TPMSSigSchemeECDSA{HashAlg: tpm2.TPMAlgSHA256},
+						),
+					},
+					CurveID: tpm2.TPMECCNistP256,
+					KDF: tpm2.TPMTKDFScheme{
+						Scheme: tpm2.TPMAlgNull,
+					},
+				},
+			),
+			Unique: tpm2.NewTPMUPublicID(tpm2.TPMAlgECC, &tpm2.TPMSECCPoint{}),
+		}),
+	}
+
+	rsp, err := create.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm create: %w", err)
+	}
+
+	pubBytes := tpm2.Marshal(rsp.OutPublic)
+
+	blob := struct {
+		Private []byte
+		Public  []byte
+	}{
+		Private: rsp.OutPrivate.Buffer,
+		Public:  pubBytes,
+	}
+
+	load := tpm2.Load{
+		ParentHandle: *srk,
+		InPrivate:    rsp.OutPrivate,
+		InPublic:     rsp.OutPublic,
+	}
+
+	loadRsp, err := load.Execute(rwc)
+	if err != nil {
+		return nil, fmt.Errorf("tpm load after create: %w", err)
+	}
+
+	jsonBytes, _ := json.Marshal(blob)
+	if err := writeBlob(filepath.Join(s.Dir, signerKeyFile), jsonBytes); err != nil {
+		return nil, err
+	}
+
+	return &tpm2.AuthHandle{
+		Handle: loadRsp.ObjectHandle,
+		Name:   loadRsp.Name,
+		Auth:   tpm2.PasswordAuth(nil),
+	}, nil
+}
+
+func getKeyPublic(rwc transport.TPM, handle tpm2.TPMHandle) (crypto.PublicKey, error) {
+	rp := tpm2.ReadPublic{ObjectHandle: handle}
+	rsp, err := rp.Execute(rwc)
+	if err != nil {
+		return nil, err
+	}
+
+	pub, err := rsp.OutPublic.Contents()
+	if err != nil {
+		return nil, err
+	}
+
+	ecc, err := pub.Parameters.ECCDetail()
+	if err != nil {
+		return nil, err
+	}
+
+	if ecc.CurveID != tpm2.TPMECCNistP256 {
+		return nil, fmt.Errorf("unsupported curve: %v", ecc.CurveID)
+	}
+
+	unique, err := pub.Unique.ECC()
+	if err != nil {
+		return nil, err
+	}
+
+	x := big.NewInt(0).SetBytes(unique.X.Buffer)
+	y := big.NewInt(0).SetBytes(unique.Y.Buffer)
+
+	return &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     x,
+		Y:     y,
+	}, nil
+}


### PR DESCRIPTION
For the CLI token package, we have a platform signer/cache for macOS only. It would be nice to support other platforms.

This creates a new, experimental module in tpmsecrets that matches the current interface, using tpm-wrapped blobs on disk. This does not give us quite the same level of security as the keychain, but is much better than just keeping things around in plaintext.

A new submodule was used for this, to avoid having tpm imports which are less likely to be used in the main module. 

Registration is added in the CLI token package. Both this and the current interfaces feel a little bit off, will re-visit that in future.