### PR TITLE
Make middleware more targeted

### DIFF
--- a/middleware/cookie_state.go
+++ b/middleware/cookie_state.go
@@ -1,4 +1,4 @@
-package oidcmiddleware
+package middleware
 
 import (
 	"errors"

--- a/middleware/cookie_state_test.go
+++ b/middleware/cookie_state_test.go
@@ -1,4 +1,4 @@
-package oidcmiddleware
+package middleware
 
 import (
 	"encoding/base64"

--- a/middleware/session.go
+++ b/middleware/session.go
@@ -1,0 +1,25 @@
+package middleware
+
+import "lds.li/oauth2ext/oidc"
+
+// SessionData contains the data this middleware needs to save/restore across
+// requests. This should be stored using a method that does not reveal the
+// contents to the end user in any way.
+type SessionData struct {
+	// Logins tracks state for in-progress logins.
+	Logins []SessionDataLogin `json:"logins,omitempty"`
+	// Token contains the issued token from a successful authentication flow.
+	Token *oidc.TokenWithID `json:"token,omitempty"`
+}
+
+// SessionDataLogin tracks state for an in-progress auth flow.
+type SessionDataLogin struct {
+	// State for an in-progress auth flow.
+	State string `json:"oidc_state,omitempty"`
+	// PKCEChallenge for the in-progress auth flow
+	PKCEChallenge string `json:"pkce_challenge,omitempty"`
+	// ReturnTo is where we should navigate to at the end of the flow
+	ReturnTo string `json:"oidc_return_to,omitempty"`
+	// Expires is when this can be discarded, Unix time.
+	Expires int `json:"expires,omitempty"`
+}


### PR DESCRIPTION
The current middleware is a bit catch-all, which makes it hard to target to specific use-cases. Some callers might want simple SSO login, others might want to delegate API access. This gets harder with the custom claims types, and also doesn't support nesting very well. Make the current middleware generic, and target the OIDC user login case only. This leaves us room to expand to delegated access, API access etc. a bit more later in more specific handlers.

Remove the dynamic config, if that is needed the consumer should replace the middleware. Maybe we'll add helpers for that later, but now let's keep it on the simpler side.