### PR TITLE
keychainsecrets: Allow specifying label, test, update keychain

### DIFF
--- a/keychainsecrets/auto/auto_darwin.go
+++ b/keychainsecrets/auto/auto_darwin.go
@@ -9,10 +9,11 @@ import (
 	"lds.li/oauth2ext/keychainsecrets"
 )
 
+const sepSignerLabel = "oauth2ext-cli-sep"
+
 func init() {
 	platformsecrets.RegisterPlatformSigner(func() (crypto.Signer, error) {
-		return keychainsecrets.NewSEPSigner()
+		return keychainsecrets.NewSEPSigner(sepSignerLabel)
 	})
-
 	platformsecrets.RegisterCredentialCache(&keychainsecrets.KeychainCredentialCache{})
 }

--- a/keychainsecrets/go.mod
+++ b/keychainsecrets/go.mod
@@ -6,7 +6,7 @@ replace lds.li/oauth2ext => ../
 
 require (
 	golang.org/x/oauth2 v0.34.0
-	lds.li/keychain v0.1.0
+	lds.li/keychain v0.1.1-0.20260207204813-c020dde5cf1c
 	lds.li/oauth2ext v0.0.0-00010101000000-000000000000
 )
 

--- a/keychainsecrets/go.sum
+++ b/keychainsecrets/go.sum
@@ -20,3 +20,5 @@ lds.li/keychain v0.0.0-20260125191015-a9e54317a85c h1:X4fYg+GGKepHZQ6D3He+HEF/80
 lds.li/keychain v0.0.0-20260125191015-a9e54317a85c/go.mod h1:7FBBMA51yibUWiHqAGjboezcfq0AyzKf6153Z1VKceM=
 lds.li/keychain v0.1.0 h1:qyQGNM3a2/dCRXQB8p4C8e7Q/ZTtAHOfbeymFQ7uY/8=
 lds.li/keychain v0.1.0/go.mod h1:7FBBMA51yibUWiHqAGjboezcfq0AyzKf6153Z1VKceM=
+lds.li/keychain v0.1.1-0.20260207204813-c020dde5cf1c h1:1+hgb/aGwTMgMArU+uNM1OzsHs0Y4NkP8CHtsylYgfQ=
+lds.li/keychain v0.1.1-0.20260207204813-c020dde5cf1c/go.mod h1:7FBBMA51yibUWiHqAGjboezcfq0AyzKf6153Z1VKceM=

--- a/keychainsecrets/signer_test.go
+++ b/keychainsecrets/signer_test.go
@@ -1,0 +1,45 @@
+//go:build darwin
+
+package keychainsecrets
+
+import (
+	"crypto/ecdsa"
+	"os"
+	"testing"
+)
+
+const testSignerLabel = "oauth2ext-test-signer"
+
+func TestSigner(t *testing.T) {
+	if os.Getenv("TEST_KEYCHAIN") == "" {
+		t.Skip("TEST_KEYCHAIN not set")
+		return
+	}
+
+	signer, err := NewSEPSigner(testSignerLabel)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	if signer == nil {
+		t.Fatal("signer is nil")
+	}
+	pub1 := signer.Public()
+	pub1ecdsa, ok := pub1.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("public key is not an ECDSA public key")
+	}
+
+	signer2, err := NewSEPSigner(testSignerLabel)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	pub2 := signer2.Public()
+	pub2ecdsa, ok := pub2.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatal("public key is not an ECDSA public key")
+	}
+
+	if !pub1ecdsa.Equal(pub2ecdsa) {
+		t.Fatal("public keys are not equal")
+	}
+}


### PR DESCRIPTION
Users might want to choose a label, so allow passing one in. The current default is moved to the auto package.

Add a test to make sure getting a signer works properly.

Update the keychain dep to fix a bug around not detecting not found identities.