### PR TITLE
Make grant expiration explicit

### DIFF
--- a/oauth2as/e2e_test.go
+++ b/oauth2as/e2e_test.go
@@ -96,11 +96,12 @@ func TestE2E(t *testing.T) {
 			signer, jwtVerifier := getTestSigner(t)
 
 			opcfg := oauth2as.Config{
-				Issuer:         oidcSvr.URL,
-				Storage:        s,
-				Signer:         signer,
-				Verifier:       jwtVerifier,
-				MaxRefreshTime: 1 * time.Hour,
+				Issuer:               oidcSvr.URL,
+				Storage:              s,
+				Signer:               signer,
+				Verifier:             jwtVerifier,
+				RefreshTokenValidity: 1 * time.Hour,
+				GrantValidity:        1 * time.Hour,
 				TokenHandler: func(_ context.Context, req *oauth2as.TokenRequest) (*oauth2as.TokenResponse, error) {
 					return &oauth2as.TokenResponse{}, nil
 				},

--- a/oauth2as/encrypted_metadata_test.go
+++ b/oauth2as/encrypted_metadata_test.go
@@ -69,11 +69,12 @@ func TestEncryptedMetadataFlow(t *testing.T) {
 	signer, jwtVerifier := getTestSigner(t)
 
 	opcfg := oauth2as.Config{
-		Issuer:         oidcSvr.URL,
-		Storage:        s,
-		Signer:         signer,
-		Verifier:       jwtVerifier,
-		MaxRefreshTime: 1 * time.Hour,
+		Issuer:               oidcSvr.URL,
+		Storage:              s,
+		Signer:               signer,
+		Verifier:             jwtVerifier,
+		RefreshTokenValidity: 1 * time.Hour,
+		GrantValidity:        1 * time.Hour,
 		TokenHandler: func(_ context.Context, req *oauth2as.TokenRequest) (*oauth2as.TokenResponse, error) {
 			metadataSeenByHandler = req.DecryptedMetadata
 			handlerCalled <- struct{}{}

--- a/oauth2as/rotation_test.go
+++ b/oauth2as/rotation_test.go
@@ -43,7 +43,8 @@ func TestRefreshTokenRotationAndGrace(t *testing.T) {
 			},
 		},
 		RefreshTokenRotationGracePeriod: 1 * time.Second,
-		MaxRefreshTime:                  1 * time.Hour,
+		RefreshTokenValidity:            1 * time.Hour,
+		GrantValidity:                   1 * time.Hour,
 	}
 
 	op, err := oauth2as.NewServer(opcfg)
@@ -173,7 +174,8 @@ func TestConcurrentRefreshAttempts(t *testing.T) {
 			},
 		},
 		RefreshTokenRotationGracePeriod: 1 * time.Second,
-		MaxRefreshTime:                  1 * time.Hour,
+		RefreshTokenValidity:            1 * time.Hour,
+		GrantValidity:                   1 * time.Hour,
 	}
 
 	op, err := oauth2as.NewServer(opcfg)
@@ -295,7 +297,8 @@ func TestReplacedByTokenIDTracking(t *testing.T) {
 			},
 		},
 		RefreshTokenRotationGracePeriod: 1 * time.Second,
-		MaxRefreshTime:                  1 * time.Hour,
+		RefreshTokenValidity:            1 * time.Hour,
+		GrantValidity:                   1 * time.Hour,
 	}
 
 	op, err := oauth2as.NewServer(opcfg)
@@ -429,7 +432,8 @@ func TestEncryptedMetadataWithRotation(t *testing.T) {
 				Opts:         []oauth2as.ClientOpt{oauth2as.ClientOptSkipPKCE()},
 			},
 		},
-		MaxRefreshTime: 1 * time.Hour,
+		RefreshTokenValidity: 1 * time.Hour,
+		GrantValidity:        1 * time.Hour,
 	}
 
 	op, err := oauth2as.NewServer(opcfg)


### PR DESCRIPTION
Going back to the older data model, we made the expiration grant implicit. It was then bumped on change as needed. This made it hard to set an absolute lifetime for a grant, and there was no way to customize it on a per-grant basis.

This splits the old "MaxRefreshTime" into a lifetime for a grant, and a lifetime for individual refresh tokens. These can both be managed at a server level, and at a per-request level.

It does make grants stick around for longer as they aren't automatically removed on token expiry, garbage collection processes can take this in to account if desired.