### PR TITLE
Export lower-level oauth2 library

### DIFF
--- a/oauth2as/dpop_test.go
+++ b/oauth2as/dpop_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/tink-crypto/tink-go/v2/jwt"
 	"lds.li/oauth2ext/dpop"
 	"lds.li/oauth2ext/internal/th"
-	"lds.li/oauth2ext/oauth2as/internal/oauth2"
 	"lds.li/oauth2ext/oauth2as/internal/token"
+	"lds.li/oauth2ext/oauth2as/oauth2proto"
 	"lds.li/oauth2ext/oidc"
 )
 
@@ -86,8 +86,8 @@ func TestDPoPTokenFlow(t *testing.T) {
 		req.Host = "localhost"
 		req.Header.Set("DPoP", dpopProof)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeAuthorizationCode,
 			Code:         codeToken,
 			RedirectURI:  redirectURI,
 			ClientID:     clientID,
@@ -209,8 +209,8 @@ func TestDPoPTokenFlow(t *testing.T) {
 			req.Host = "localhost"
 			req.Header.Set("DPoP", dpopProof)
 
-			treq := &oauth2.TokenRequest{
-				GrantType:    oauth2.GrantTypeRefreshToken,
+			treq := &oauth2proto.TokenRequest{
+				GrantType:    oauth2proto.GrantTypeRefreshToken,
 				RefreshToken: refreshTokenStr,
 				ClientID:     clientID,
 				ClientSecret: clientSecret,
@@ -266,8 +266,8 @@ func TestDPoPTokenFlow(t *testing.T) {
 			// Request without DPoP header
 			req := httptest.NewRequest(http.MethodPost, "/token", nil)
 
-			treq := &oauth2.TokenRequest{
-				GrantType:    oauth2.GrantTypeRefreshToken,
+			treq := &oauth2proto.TokenRequest{
+				GrantType:    oauth2proto.GrantTypeRefreshToken,
 				RefreshToken: refreshTokenStr2,
 				ClientID:     clientID,
 				ClientSecret: clientSecret,
@@ -278,11 +278,11 @@ func TestDPoPTokenFlow(t *testing.T) {
 				t.Fatal("expected error when DPoP proof is missing")
 			}
 
-			tokenErr, ok := err.(*oauth2.TokenError)
+			tokenErr, ok := err.(*oauth2proto.TokenError)
 			if !ok {
 				t.Fatalf("expected TokenError, got %T", err)
 			}
-			if tokenErr.ErrorCode != oauth2.TokenErrorCodeInvalidGrant {
+			if tokenErr.ErrorCode != oauth2proto.TokenErrorCodeInvalidGrant {
 				t.Errorf("expected invalid_grant error, got %s", tokenErr.ErrorCode)
 			}
 		})
@@ -348,8 +348,8 @@ func TestDPoPTokenFlow(t *testing.T) {
 			req.Host = "localhost"
 			req.Header.Set("DPoP", wrongProof)
 
-			treq := &oauth2.TokenRequest{
-				GrantType:    oauth2.GrantTypeRefreshToken,
+			treq := &oauth2proto.TokenRequest{
+				GrantType:    oauth2proto.GrantTypeRefreshToken,
 				RefreshToken: refreshTokenStr3,
 				ClientID:     clientID,
 				ClientSecret: clientSecret,
@@ -360,11 +360,11 @@ func TestDPoPTokenFlow(t *testing.T) {
 				t.Fatal("expected error when DPoP key doesn't match")
 			}
 
-			tokenErr, ok := err.(*oauth2.TokenError)
+			tokenErr, ok := err.(*oauth2proto.TokenError)
 			if !ok {
 				t.Fatalf("expected TokenError, got %T", err)
 			}
-			if tokenErr.ErrorCode != oauth2.TokenErrorCodeInvalidGrant {
+			if tokenErr.ErrorCode != oauth2proto.TokenErrorCodeInvalidGrant {
 				t.Errorf("expected invalid_grant error, got %s", tokenErr.ErrorCode)
 			}
 		})

--- a/oauth2as/internal/oauth2/doc.go
+++ b/oauth2as/internal/oauth2/doc.go
@@ -1,3 +1,0 @@
-// Package oauth2 implements base primitives for parsing a subset of oauth2
-// messages and errors
-package oauth2

--- a/oauth2as/oauth2proto/auth.go
+++ b/oauth2as/oauth2proto/auth.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth2proto
 
 import (
 	"fmt"

--- a/oauth2as/oauth2proto/auth_test.go
+++ b/oauth2as/oauth2proto/auth_test.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth2proto
 
 import (
 	"fmt"

--- a/oauth2as/oauth2proto/doc.go
+++ b/oauth2as/oauth2proto/doc.go
@@ -1,0 +1,3 @@
+// Package oauth2proto implements base primitives for parsing a subset of oauth2
+// messages and errors
+package oauth2proto

--- a/oauth2as/oauth2proto/errors.go
+++ b/oauth2as/oauth2proto/errors.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth2proto
 
 import (
 	"encoding/json"

--- a/oauth2as/oauth2proto/errors_test.go
+++ b/oauth2as/oauth2proto/errors_test.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth2proto
 
 import (
 	"encoding/json"

--- a/oauth2as/oauth2proto/token.go
+++ b/oauth2as/oauth2proto/token.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth2proto
 
 import (
 	"encoding/json"

--- a/oauth2as/oauth2proto/token_test.go
+++ b/oauth2as/oauth2proto/token_test.go
@@ -1,4 +1,4 @@
-package oauth2
+package oauth2proto
 
 import (
 	"encoding/json"

--- a/oauth2as/server.go
+++ b/oauth2as/server.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/tink-crypto/tink-go/v2/jwt"
 	"lds.li/oauth2ext/dpop"
-	"lds.li/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/oauth2proto"
 )
 
 const (
@@ -168,18 +168,18 @@ func NewServer(c Config) (*Server, error) {
 	return svr, nil
 }
 
-func (s *Server) validateTokenClient(ctx context.Context, req *oauth2.TokenRequest, wantClientID string) error {
+func (s *Server) validateTokenClient(ctx context.Context, req *oauth2proto.TokenRequest, wantClientID string) error {
 	// check to see if we're working with the same client
 	if wantClientID != req.ClientID {
-		return &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeUnauthorizedClient, Description: "", Cause: fmt.Errorf("code redeemed for wrong client")}
+		return &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeUnauthorizedClient, Description: "", Cause: fmt.Errorf("code redeemed for wrong client")}
 	}
 
 	secrets, err := s.config.Clients.ClientSecrets(ctx, req.ClientID)
 	if err != nil {
-		return &oauth2.HTTPError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "failed to get client secrets", Cause: err}
+		return &oauth2proto.HTTPError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "failed to get client secrets", Cause: err}
 	}
 	if len(secrets) == 0 {
-		return &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeUnauthorizedClient, Description: "Invalid client secret"}
+		return &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeUnauthorizedClient, Description: "Invalid client secret"}
 	}
 
 	var matchFound int32
@@ -187,8 +187,8 @@ func (s *Server) validateTokenClient(ctx context.Context, req *oauth2.TokenReque
 		matchFound |= int32(subtle.ConstantTimeCompare([]byte(secret), []byte(req.ClientSecret)))
 	}
 	if matchFound != 1 {
-		return &oauth2.TokenError{
-			ErrorCode:   oauth2.TokenErrorCodeUnauthorizedClient,
+		return &oauth2proto.TokenError{
+			ErrorCode:   oauth2proto.TokenErrorCodeUnauthorizedClient,
 			Description: "Invalid client secret",
 		}
 	}

--- a/oauth2as/server_authorization.go
+++ b/oauth2as/server_authorization.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"lds.li/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/oauth2proto"
 )
 
 type AuthRequest struct {
@@ -36,7 +36,7 @@ func (s *Server) ParseAuthRequest(req *http.Request) (*AuthRequest, error) {
 	// Note: Error handling deviates from the spec - errors are returned directly
 	// rather than redirected to the client's redirect_uri.
 	// TODO - consider if we should fix this.
-	authreq, err := oauth2.ParseAuthRequest(req)
+	authreq, err := oauth2proto.ParseAuthRequest(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse auth request: %w", err)
 	}
@@ -67,7 +67,7 @@ func (s *Server) ParseAuthRequest(req *http.Request) (*AuthRequest, error) {
 	}
 
 	switch authreq.ResponseType {
-	case oauth2.ResponseTypeCode:
+	case oauth2proto.ResponseTypeCode:
 	default:
 		return nil, fmt.Errorf("response type %s is not supported", authreq.ResponseType)
 	}
@@ -158,7 +158,7 @@ func (s *Server) GrantAuth(ctx context.Context, grant *AuthGrant) (redirectURI s
 		return "", fmt.Errorf("failed to parse authreq's URI: %w", err)
 	}
 
-	codeResp := &oauth2.CodeAuthResponse{
+	codeResp := &oauth2proto.CodeAuthResponse{
 		RedirectURI: redir,
 		State:       grant.Request.State,
 		Code:        authCodeString,

--- a/oauth2as/server_test.go
+++ b/oauth2as/server_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/tink-crypto/tink-go/v2/jwt"
 	"lds.li/oauth2ext/internal/th"
 	"lds.li/oauth2ext/oauth2as/internal"
-	"lds.li/oauth2ext/oauth2as/internal/oauth2"
 	"lds.li/oauth2ext/oauth2as/internal/token"
+	"lds.li/oauth2ext/oauth2as/oauth2proto"
 	"lds.li/oauth2ext/oidc"
 )
 
@@ -93,8 +93,8 @@ func TestCodeToken(t *testing.T) {
 		o := newOIDC()
 		codeToken := newCodeGrant(t, o.config.Storage)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeAuthorizationCode,
 			Code:         codeToken,
 			RedirectURI:  redirectURI,
 			ClientID:     clientID,
@@ -115,8 +115,8 @@ func TestCodeToken(t *testing.T) {
 		o := newOIDC()
 		codeToken := newCodeGrant(t, o.config.Storage)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeAuthorizationCode,
 			Code:         codeToken,
 			RedirectURI:  redirectURI,
 			ClientID:     clientID,
@@ -130,7 +130,7 @@ func TestCodeToken(t *testing.T) {
 
 		// replay fails
 		_, err = o.codeToken(context.Background(), httptest.NewRequest(http.MethodPost, "/token", nil), treq)
-		if err, ok := err.(*oauth2.TokenError); !ok || err.ErrorCode != oauth2.TokenErrorCodeInvalidGrant {
+		if err, ok := err.(*oauth2proto.TokenError); !ok || err.ErrorCode != oauth2proto.TokenErrorCodeInvalidGrant {
 			t.Errorf("want invalid token grant error, got: %v", err)
 		}
 	})
@@ -139,8 +139,8 @@ func TestCodeToken(t *testing.T) {
 		o := newOIDC()
 		codeToken := newCodeGrant(t, o.config.Storage)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeAuthorizationCode,
 			Code:         codeToken,
 			RedirectURI:  redirectURI,
 			ClientID:     clientID,
@@ -148,7 +148,7 @@ func TestCodeToken(t *testing.T) {
 		}
 
 		_, err := o.codeToken(context.Background(), httptest.NewRequest(http.MethodPost, "/token", nil), treq)
-		if err, ok := err.(*oauth2.TokenError); !ok || err.ErrorCode != oauth2.TokenErrorCodeUnauthorizedClient {
+		if err, ok := err.(*oauth2proto.TokenError); !ok || err.ErrorCode != oauth2proto.TokenErrorCodeUnauthorizedClient {
 			t.Errorf("want unauthorized client error, got: %v", err)
 		}
 	})
@@ -157,8 +157,8 @@ func TestCodeToken(t *testing.T) {
 		o := newOIDC()
 		codeToken := newCodeGrant(t, o.config.Storage)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:   oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:   oauth2proto.GrantTypeAuthorizationCode,
 			Code:        codeToken,
 			RedirectURI: redirectURI,
 			// This is not the credentials the code should be tracking, but are
@@ -168,7 +168,7 @@ func TestCodeToken(t *testing.T) {
 		}
 
 		_, err := o.codeToken(context.Background(), httptest.NewRequest(http.MethodPost, "/token", nil), treq)
-		if err, ok := err.(*oauth2.TokenError); !ok || err.ErrorCode != oauth2.TokenErrorCodeUnauthorizedClient {
+		if err, ok := err.(*oauth2proto.TokenError); !ok || err.ErrorCode != oauth2proto.TokenErrorCodeUnauthorizedClient {
 			t.Errorf("want unauthorized client error, got: %v", err)
 		}
 	})
@@ -177,8 +177,8 @@ func TestCodeToken(t *testing.T) {
 		o := newOIDC()
 		codeToken := newCodeGrant(t, o.config.Storage)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeAuthorizationCode,
 			Code:         codeToken,
 			RedirectURI:  redirectURI,
 			ClientID:     clientID,
@@ -246,8 +246,8 @@ func TestCodeToken(t *testing.T) {
 		}
 		authCodeStr := newToken.ToUser(authCodeID)
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeAuthorizationCode,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeAuthorizationCode,
 			Code:         authCodeStr,
 			RedirectURI:  es256ClientRedirect,
 			ClientID:     es256ClientID,
@@ -355,8 +355,8 @@ func TestRefreshToken(t *testing.T) {
 
 		// keep trying to refresh
 		for i := 1; i <= 5; i++ {
-			treq := &oauth2.TokenRequest{
-				GrantType:    oauth2.GrantTypeRefreshToken,
+			treq := &oauth2proto.TokenRequest{
+				GrantType:    oauth2proto.GrantTypeRefreshToken,
 				RefreshToken: refreshToken,
 				ClientID:     clientID,
 				ClientSecret: clientSecret,
@@ -381,8 +381,8 @@ func TestRefreshToken(t *testing.T) {
 		// try again while we still should be within the expiry period.
 		o.now = func() time.Time { return time.Now().Add(5 * time.Hour) }
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeRefreshToken,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeRefreshToken,
 			RefreshToken: refreshToken,
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
@@ -400,15 +400,15 @@ func TestRefreshToken(t *testing.T) {
 		// march to the future, when we should be expired
 		o.now = func() time.Time { return time.Now().Add(7 * time.Hour) }
 
-		treq = &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeRefreshToken,
+		treq = &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeRefreshToken,
 			RefreshToken: refreshToken,
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 		}
 
 		_, err = o.refreshToken(context.Background(), httptest.NewRequest(http.MethodPost, "/token", nil), treq)
-		if te, ok := err.(*oauth2.TokenError); !ok || te.ErrorCode != oauth2.TokenErrorCodeInvalidGrant {
+		if te, ok := err.(*oauth2proto.TokenError); !ok || te.ErrorCode != oauth2proto.TokenErrorCodeInvalidGrant {
 			t.Errorf("expired session should have given invalid_grant, got: %v", te)
 		}
 	})
@@ -432,8 +432,8 @@ func TestRefreshToken(t *testing.T) {
 		// try and refresh, and observe intentional unauth error
 		returnErr = &unauthorizedErrImpl{error: errors.New(errDesc)}
 
-		treq := &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeRefreshToken,
+		treq := &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeRefreshToken,
 			RefreshToken: refreshToken,
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
@@ -444,12 +444,12 @@ func TestRefreshToken(t *testing.T) {
 		if err == nil {
 			t.Fatal("want error refreshing, got none")
 		}
-		terr, ok := err.(*oauth2.TokenError)
+		terr, ok := err.(*oauth2proto.TokenError)
 		if !ok {
 			t.Fatalf("want token error, got: %T", err)
 		}
-		if terr.ErrorCode != oauth2.TokenErrorCodeInvalidGrant || terr.Description != errDesc {
-			t.Fatalf("unexpected code %q (want %q) or description %q (want %q)", terr.ErrorCode, oauth2.TokenErrorCodeInvalidGrant, terr.Description, errDesc)
+		if terr.ErrorCode != oauth2proto.TokenErrorCodeInvalidGrant || terr.Description != errDesc {
+			t.Fatalf("unexpected code %q (want %q) or description %q (want %q)", terr.ErrorCode, oauth2proto.TokenErrorCodeInvalidGrant, terr.Description, errDesc)
 		}
 
 		// refresh with generic err
@@ -457,8 +457,8 @@ func TestRefreshToken(t *testing.T) {
 
 		returnErr = errors.New("boomtown")
 
-		treq = &oauth2.TokenRequest{
-			GrantType:    oauth2.GrantTypeRefreshToken,
+		treq = &oauth2proto.TokenRequest{
+			GrantType:    oauth2proto.GrantTypeRefreshToken,
 			RefreshToken: refreshToken,
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
@@ -469,7 +469,7 @@ func TestRefreshToken(t *testing.T) {
 		if err == nil {
 			t.Fatal("want error refreshing, got none")
 		}
-		if _, ok = err.(*oauth2.HTTPError); !ok {
+		if _, ok = err.(*oauth2proto.HTTPError); !ok {
 			t.Fatalf("want http error, got %T (%v)", err, err)
 		}
 	})

--- a/oauth2as/server_token.go
+++ b/oauth2as/server_token.go
@@ -16,8 +16,8 @@ import (
 	"github.com/tink-crypto/tink-go/v2/jwt"
 	"lds.li/oauth2ext/dpop"
 	"lds.li/oauth2ext/internal/th"
-	"lds.li/oauth2ext/oauth2as/internal/oauth2"
 	"lds.li/oauth2ext/oauth2as/internal/token"
+	"lds.li/oauth2ext/oauth2as/oauth2proto"
 	"lds.li/oauth2ext/oidc"
 )
 
@@ -125,37 +125,37 @@ func (s *Server) TokenHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	treq, err := oauth2.ParseTokenRequest(req)
+	treq, err := oauth2proto.ParseTokenRequest(req)
 	if err != nil {
-		_ = oauth2.WriteError(w, req, err)
+		_ = oauth2proto.WriteError(w, req, err)
 		return
 	}
 
-	var resp *oauth2.TokenResponse
+	var resp *oauth2proto.TokenResponse
 	switch treq.GrantType {
-	case oauth2.GrantTypeAuthorizationCode:
+	case oauth2proto.GrantTypeAuthorizationCode:
 		resp, err = s.codeToken(req.Context(), req, treq)
-	case oauth2.GrantTypeRefreshToken:
+	case oauth2proto.GrantTypeRefreshToken:
 		resp, err = s.refreshToken(req.Context(), req, treq)
 	default:
-		err = &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid grant type", Cause: fmt.Errorf("grant type %s not handled", treq.GrantType)}
+		err = &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid grant type", Cause: fmt.Errorf("grant type %s not handled", treq.GrantType)}
 	}
 	if err != nil {
 		s.logger.WarnContext(req.Context(), "error in token handler", "grant-type", treq.GrantType, "err", err)
-		_ = oauth2.WriteError(w, req, err)
+		_ = oauth2proto.WriteError(w, req, err)
 		return
 	}
 
-	if err := oauth2.WriteTokenResponse(w, resp); err != nil {
+	if err := oauth2proto.WriteTokenResponse(w, resp); err != nil {
 		s.logger.ErrorContext(req.Context(), "error writing token response", "grant-type", treq.GrantType, "err", err)
-		_ = oauth2.WriteError(w, req, err)
+		_ = oauth2proto.WriteError(w, req, err)
 		return
 	}
 }
 
-func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.TokenRequest) (*oauth2.TokenResponse, error) {
+func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2proto.TokenRequest) (*oauth2proto.TokenResponse, error) {
 	if treq.Code == "" {
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidRequest, Description: "code is required"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidRequest, Description: "code is required"}
 	}
 
 	// Verify DPoP proof if present. In the code flow, we allow any thumbprint -
@@ -168,11 +168,11 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.
 	loadedGrant, err := s.getGrantFromAuthCode(ctx, treq.Code)
 	if err != nil {
 		if errors.Is(err, errGrantTokenInvalid) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid code"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid code"}
 		} else if errors.Is(err, errGrantExpired) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid code"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid code"}
 		} else if errors.Is(err, errGrantNotFound) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid code"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid code"}
 		}
 		return nil, fmt.Errorf("failed to get grant by auth code: %w", err)
 	}
@@ -180,19 +180,19 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.
 	pt, _ := token.ParseUserToken(treq.Code, tokenUsageAuthCode) // already parsed in getGrantFromAuthCode, so this is safe
 	if err := s.config.Storage.ExpireAuthCode(ctx, pt.ID()); err != nil {
 		if errors.Is(err, ErrNotFound) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid code"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid code"}
 		}
 		return nil, fmt.Errorf("failed to expire auth code: %w", err)
 	}
 
 	if loadedGrant.grant.Request == nil {
 
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid grant"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid grant"}
 	}
 
 	// Validate that the redirect_uri matches the one from the authorization request
 	if treq.RedirectURI != loadedGrant.grant.Request.RedirectURI {
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "redirect URI mismatch"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "redirect URI mismatch"}
 	}
 
 	if err := s.validateTokenClient(ctx, treq, loadedGrant.grant.ClientID); err != nil {
@@ -210,7 +210,7 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.
 
 	// Reject if PKCE is required but no code verifier was provided
 	if !copts.skipPKCE && treq.CodeVerifier == "" {
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeUnauthorizedClient, Description: "PKCE required, but code verifier not passed"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeUnauthorizedClient, Description: "PKCE required, but code verifier not passed"}
 	}
 
 	var alg *string
@@ -221,7 +221,7 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.
 	// Verify the code verifier against the session data
 	if treq.CodeVerifier != "" {
 		if !verifyCodeChallenge(treq.CodeVerifier, loadedGrant.grant.Request.CodeChallenge) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeUnauthorizedClient, Description: "PKCE verification failed"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeUnauthorizedClient, Description: "PKCE verification failed"}
 		}
 	}
 
@@ -233,7 +233,7 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.
 	// TODO: Update grant expiry when DPoP binding is added
 	if err := s.config.Storage.UpdateGrant(ctx, loadedGrant.grantID, loadedGrant.grant); err != nil {
 		if errors.Is(err, ErrConcurrentUpdate) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
 		}
 		return nil, fmt.Errorf("failed to update grant: %w", err)
 	}
@@ -260,31 +260,31 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2.
 	if err != nil {
 		var uaerr unauthorizedErr
 		if errors.As(err, &uaerr) && uaerr.Unauthorized() {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: uaerr.Error()}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: uaerr.Error()}
 		}
-		return nil, &oauth2.HTTPError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "handler returned error", Cause: err}
+		return nil, &oauth2proto.HTTPError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "handler returned error", Cause: err}
 	}
 
 	trresp, _, err := s.buildTokenResponse(ctx, alg, loadedGrant, tresp, isDPoPBound)
 	if err != nil && errors.Is(err, ErrConcurrentUpdate) {
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
 	}
 	return trresp, err
 }
 
-func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oauth2.TokenRequest) (_ *oauth2.TokenResponse, retErr error) {
+func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oauth2proto.TokenRequest) (_ *oauth2proto.TokenResponse, retErr error) {
 	if treq.RefreshToken == "" {
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidRequest, Description: "refresh token is required"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidRequest, Description: "refresh token is required"}
 	}
 
 	loadedGrant, err := s.getGrantFromRefreshToken(ctx, treq.RefreshToken)
 	if err != nil {
 		if errors.Is(err, errGrantTokenInvalid) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
 		} else if errors.Is(err, errGrantExpired) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
 		} else if errors.Is(err, errGrantNotFound) {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
 		}
 		return nil, fmt.Errorf("failed to get grant by refresh token: %w", err)
 	}
@@ -299,10 +299,10 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 			if err := s.config.Storage.ExpireGrant(ctx, loadedGrant.grantID); err != nil {
 				return nil, fmt.Errorf("failed to revoke grant on refresh token reuse: %w", err)
 			}
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
 		}
 		// Token is expired but not replaced. Just a normal expiration.
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
 	}
 
 	// Handle grace period for rotated tokens
@@ -319,14 +319,14 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 			loadedGrant.refreshToken.ValidUntil = s.now().Add(s.config.RefreshTokenRotationGracePeriod)
 			if err := s.config.Storage.UpdateRefreshToken(ctx, pt.ID(), loadedGrant.refreshToken); err != nil {
 				if errors.Is(err, ErrConcurrentUpdate) {
-					return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
+					return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
 				}
 				return nil, fmt.Errorf("failed to update refresh token with grace expiry: %w", err)
 			}
 		} else {
 			if err := s.config.Storage.ExpireRefreshToken(ctx, pt.ID()); err != nil {
 				if errors.Is(err, ErrNotFound) {
-					return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
+					return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "invalid refresh token"}
 				}
 				return nil, fmt.Errorf("failed to expire refresh token: %w", err)
 			}
@@ -342,10 +342,10 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 	if storedThumbprint != "" {
 		thumbprint, err := s.verifyDPoPProof(s.config.Issuer, req, &storedThumbprint)
 		if err != nil {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "DPoP proof key mismatch"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "DPoP proof key mismatch"}
 		}
 		if thumbprint == "" {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "DPoP proof required"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "DPoP proof required"}
 		}
 	}
 
@@ -380,9 +380,9 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 	if err != nil {
 		var uaerr unauthorizedErr
 		if errors.As(err, &uaerr) && uaerr.Unauthorized() {
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: uaerr.Error()}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: uaerr.Error()}
 		}
-		return nil, &oauth2.HTTPError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "handler returned error", Cause: err}
+		return nil, &oauth2proto.HTTPError{Code: http.StatusInternalServerError, Message: "internal error", CauseMsg: "handler returned error", Cause: err}
 	}
 
 	trresp, newRTID, err := s.buildTokenResponse(ctx, alg, loadedGrant, tresp, isDPoPBound)
@@ -391,7 +391,7 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 		if err := s.config.Storage.ExpireGrant(ctx, loadedGrant.grantID); err != nil {
 			slog.WarnContext(ctx, "failed to expire grant", "error", err)
 		}
-		return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
+		return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to build refresh token response: %w", err)
 	}
@@ -409,7 +409,7 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 			if err := s.config.Storage.ExpireGrant(ctx, loadedGrant.grantID); err != nil {
 				slog.WarnContext(ctx, "failed to expire grant", "error", err)
 			}
-			return nil, &oauth2.TokenError{ErrorCode: oauth2.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
+			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "concurrent update detected"}
 		} else if err != nil {
 			return nil, fmt.Errorf("failed to update old refresh token: %w", err)
 		}
@@ -420,7 +420,7 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 
 // buildTokenResponse creates the oauth token response for code and refresh.
 // It works with both auth code grants and refresh token grants via the grantLoader interface.
-func (s *Server) buildTokenResponse(ctx context.Context, alg *string, loadedGrant grantLoader, tresp *TokenResponse, isDPoPBound bool) (_ *oauth2.TokenResponse, refreshTokenID string, _ error) {
+func (s *Server) buildTokenResponse(ctx context.Context, alg *string, loadedGrant grantLoader, tresp *TokenResponse, isDPoPBound bool) (_ *oauth2proto.TokenResponse, refreshTokenID string, _ error) {
 	// Update metadata from the handler response
 	if tresp.Metadata != nil {
 		loadedGrant.Grant().Metadata = tresp.Metadata
@@ -506,7 +506,7 @@ func (s *Server) buildTokenResponse(ctx context.Context, alg *string, loadedGran
 		tokenType = "DPoP"
 	}
 
-	return &oauth2.TokenResponse{
+	return &oauth2proto.TokenResponse{
 		AccessToken:  atSigned,
 		RefreshToken: refreshToken,
 		TokenType:    tokenType,

--- a/oauth2as/server_userinfo.go
+++ b/oauth2as/server_userinfo.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/tink-crypto/tink-go/v2/jwt"
 	"lds.li/oauth2ext/internal/th"
-	"lds.li/oauth2ext/oauth2as/internal/oauth2"
+	"lds.li/oauth2ext/oauth2as/oauth2proto"
 )
 
 type UserinfoHandler func(ctx context.Context, uireq *UserinfoRequest) (*UserinfoResponse, error)
@@ -43,9 +43,9 @@ func (s *Server) UserinfoHandler(w http.ResponseWriter, req *http.Request) {
 
 	authSp := strings.SplitN(req.Header.Get("authorization"), " ", 2)
 	if !strings.EqualFold(authSp[0], "bearer") || len(authSp) != 2 {
-		be := &oauth2.BearerError{} // no content, just request auth
-		herr := &oauth2.HTTPError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), CauseMsg: "malformed Authorization header"}
-		_ = oauth2.WriteError(w, req, herr)
+		be := &oauth2proto.BearerError{} // no content, just request auth
+		herr := &oauth2proto.HTTPError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), CauseMsg: "malformed Authorization header"}
+		_ = oauth2proto.WriteError(w, req, herr)
 		return
 	}
 
@@ -54,18 +54,18 @@ func (s *Server) UserinfoHandler(w http.ResponseWriter, req *http.Request) {
 	atJWT, err := s.verifyAccessToken(authSp[1])
 	if err != nil {
 		slog.ErrorContext(req.Context(), "invalid access token", "error", err)
-		be := &oauth2.BearerError{Code: oauth2.BearerErrorCodeInvalidRequest, Description: "invalid access token"}
-		herr := &oauth2.HTTPError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), Cause: err}
-		_ = oauth2.WriteError(w, req, herr)
+		be := &oauth2proto.BearerError{Code: oauth2proto.BearerErrorCodeInvalidRequest, Description: "invalid access token"}
+		herr := &oauth2proto.HTTPError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), Cause: err}
+		_ = oauth2proto.WriteError(w, req, herr)
 		return
 	}
 
 	atSub, err := atJWT.Subject()
 	if err != nil {
 		slog.ErrorContext(req.Context(), "invalid access token", "error", err)
-		be := &oauth2.BearerError{Code: oauth2.BearerErrorCodeInvalidRequest, Description: "invalid access token"}
-		herr := &oauth2.HTTPError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), Cause: err}
-		_ = oauth2.WriteError(w, req, herr)
+		be := &oauth2proto.BearerError{Code: oauth2proto.BearerErrorCodeInvalidRequest, Description: "invalid access token"}
+		herr := &oauth2proto.HTTPError{Code: http.StatusUnauthorized, WWWAuthenticate: be.String(), Cause: err}
+		_ = oauth2proto.WriteError(w, req, herr)
 		return
 	}
 
@@ -79,20 +79,20 @@ func (s *Server) UserinfoHandler(w http.ResponseWriter, req *http.Request) {
 	// TODO: Return an error if UserinfoHandler is not configured
 	uiresp, err := s.config.UserinfoHandler(req.Context(), uireq)
 	if err != nil {
-		herr := &oauth2.HTTPError{Code: http.StatusInternalServerError, Cause: err, CauseMsg: "error in user handler"}
-		_ = oauth2.WriteError(w, req, herr)
+		herr := &oauth2proto.HTTPError{Code: http.StatusInternalServerError, Cause: err, CauseMsg: "error in user handler"}
+		_ = oauth2proto.WriteError(w, req, herr)
 		return
 	}
 	if uiresp.Identity == nil {
-		herr := &oauth2.HTTPError{Code: http.StatusInternalServerError, Cause: err, CauseMsg: "userinfo has no identity"}
-		_ = oauth2.WriteError(w, req, herr)
+		herr := &oauth2proto.HTTPError{Code: http.StatusInternalServerError, Cause: err, CauseMsg: "userinfo has no identity"}
+		_ = oauth2proto.WriteError(w, req, herr)
 		return
 	}
 
 	// TODO: Pre-populate standard claims (iss, aud, etc.) in the identity response
 
 	if err := json.NewEncoder(w).Encode(uiresp.Identity); err != nil {
-		_ = oauth2.WriteError(w, req, err)
+		_ = oauth2proto.WriteError(w, req, err)
 		return
 	}
 }


### PR DESCRIPTION
There's been a few times where this would have been useful externally. It was historically internal because it wasn't considered stable and was an implementation detail of the old setup, this doesn't stand up anymore so make it exported.