### PR TITLE
dpop: Support verifying and creating x509 bound tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin/golangci-lint*
 /*.test
 go.work*
+go.work*

--- a/dpop/jwk.go
+++ b/dpop/jwk.go
@@ -306,13 +306,8 @@ func canonicalizeJWK(jwk map[string]any) ([]byte, error) {
 
 // calculateJWKThumbprint calculates the JWK thumbprint per RFC 7638.
 // Returns the base64url-encoded SHA-256 hash of the canonical JWK.
-func calculateJWKThumbprint(jwk any) (string, error) {
-	jwkMap, ok := jwk.(map[string]any)
-	if !ok {
-		return "", fmt.Errorf("jwk is not a map")
-	}
-
-	canonical, err := canonicalizeJWK(jwkMap)
+func calculateJWKThumbprint(jwk map[string]any) (string, error) {
+	canonical, err := canonicalizeJWK(jwk)
 	if err != nil {
 		return "", fmt.Errorf("canonicalizing JWK: %w", err)
 	}

--- a/dpop/jwt.go
+++ b/dpop/jwt.go
@@ -2,9 +2,11 @@ package dpop
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // parseToken parses a JWT token string into its three parts: header, claims, and signature.
@@ -26,7 +28,7 @@ func parseToken(s string) (header, claims, sig string, ok bool) {
 }
 
 // parseJWTHeader extracts and parses the JWT header from a compact JWT string.
-func parseJWTHeader(compact string) (map[string]any, error) {
+func parseJWTHeader(compact string) (*structpb.Struct, error) {
 	headerB64, _, _, ok := parseToken(compact)
 	if !ok {
 		return nil, fmt.Errorf("malformed JWT: expected format header.payload.signature")
@@ -37,10 +39,35 @@ func parseJWTHeader(compact string) (map[string]any, error) {
 		return nil, fmt.Errorf("decoding header: %w", err)
 	}
 
-	var header map[string]any
-	if err := json.Unmarshal(headerJSON, &header); err != nil {
+	var header structpb.Struct
+	if err := protojson.Unmarshal(headerJSON, &header); err != nil {
 		return nil, fmt.Errorf("unmarshaling header: %w", err)
 	}
+	return &header, nil
+}
 
-	return header, nil
+func hasClaimOfKind(s *structpb.Struct, name string, kind *structpb.Value) bool {
+	val, exist := s.GetFields()[name]
+	if !exist || kind == nil {
+		return false
+	}
+	var isKind bool
+	switch kind.GetKind().(type) {
+	case *structpb.Value_StructValue:
+		_, isKind = val.GetKind().(*structpb.Value_StructValue)
+	case *structpb.Value_NullValue:
+		_, isKind = val.GetKind().(*structpb.Value_NullValue)
+	case *structpb.Value_BoolValue:
+		_, isKind = val.GetKind().(*structpb.Value_BoolValue)
+	case *structpb.Value_ListValue:
+		_, isKind = val.GetKind().(*structpb.Value_ListValue)
+	case *structpb.Value_StringValue:
+		_, isKind = val.GetKind().(*structpb.Value_StringValue)
+	case *structpb.Value_NumberValue:
+		_, isKind = val.GetKind().(*structpb.Value_NumberValue)
+	default:
+		isKind = false
+
+	}
+	return isKind
 }

--- a/dpop/signer.go
+++ b/dpop/signer.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/sha512"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -22,6 +23,9 @@ import (
 type Signer struct {
 	signer crypto.Signer
 	jwk    map[string]any
+	// x5c, when non-empty, is the RFC 7515 x5c header (base64-encoded DER
+	// PKIX), leaf first, same order as passed to NewSignerWithCertificateChain.
+	x5c []string
 }
 
 // NewSigner creates a new Signer using the provided [crypto.Signer].
@@ -38,6 +42,49 @@ func NewSigner(signer crypto.Signer) (*Signer, error) {
 	}, nil
 }
 
+// NewSignerWithCertificateChain returns a Signer that includes an x5c JWT
+// header built from chain. The leaf certificate (chain[0]) must contain the
+// same public key as signer. Remaining entries are intermediates and/or the
+// root, in order from leaf toward trust.
+//
+// Note: This is an experimental, non-standard extension to the DPoP spec. It
+// presents privacy concerns as it potntially exposes information about the
+// user, and is intended for use in enterprise scenarios only.
+func NewSignerWithCertificateChain(signer crypto.Signer, chain []*x509.Certificate) (*Signer, error) {
+	if len(chain) == 0 {
+		return nil, fmt.Errorf("certificate chain is empty")
+	}
+	if !leafCertMatchesSigner(chain[0], signer.Public()) {
+		return nil, fmt.Errorf("leaf certificate public key does not match signer")
+	}
+	jwk, err := publicKeyToJWK(signer.Public())
+	if err != nil {
+		return nil, fmt.Errorf("creating JWK: %w", err)
+	}
+	x5c := make([]string, len(chain))
+	for i, c := range chain {
+		x5c[i] = base64.StdEncoding.EncodeToString(c.Raw)
+	}
+	return &Signer{
+		signer: signer,
+		jwk:    jwk,
+		x5c:    x5c,
+	}, nil
+}
+
+func leafCertMatchesSigner(leaf *x509.Certificate, pub crypto.PublicKey) bool {
+	switch cp := leaf.PublicKey.(type) {
+	case *ecdsa.PublicKey:
+		sp, ok := pub.(*ecdsa.PublicKey)
+		return ok && cp.Equal(sp)
+	case *rsa.PublicKey:
+		sp, ok := pub.(*rsa.PublicKey)
+		return ok && cp.Equal(sp)
+	default:
+		return false
+	}
+}
+
 // SignAndEncode signs the JWT as a DPoP proof, and returns the compact JWT.
 func (e *Signer) SignAndEncode(raw *jwt.RawJWTOptions) (string, error) {
 	raw.TypeHeader = th.Ptr("dpop+jwt")
@@ -45,9 +92,11 @@ func (e *Signer) SignAndEncode(raw *jwt.RawJWTOptions) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("creating raw JWT: %w", err)
 	}
-	return e.encodeWithHeaders(rawJWT, map[string]any{
-		"jwk": e.jwk,
-	})
+	headers := map[string]any{"jwk": e.jwk}
+	if len(e.x5c) > 0 {
+		headers["x5c"] = e.x5c
+	}
+	return e.encodeWithHeaders(rawJWT, headers)
 }
 
 // encodeWithHeaders encodes a JWT with additional custom headers. If a key

--- a/dpop/verifier.go
+++ b/dpop/verifier.go
@@ -1,12 +1,16 @@
 package dpop
 
 import (
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"maps"
 	"time"
 
 	"github.com/tink-crypto/tink-go/v2/jwt"
+	"github.com/tink-crypto/tink-go/v2/keyset"
+	"google.golang.org/protobuf/types/known/structpb"
 	"lds.li/oauth2ext/internal/th"
 )
 
@@ -19,6 +23,12 @@ type Verifier struct {
 	// if it has no explicit expiry. Defaults to DefaultValidityAfterIssue.
 	ValidityAfterIssue time.Duration
 
+	// TrustedRoots, when non-nil, requires a non-empty x5c JWT header. The leaf
+	// certificate must chain to one of these roots (per x509.Verify). The JWT
+	// signature is verified using the leaf certificate's public key. When nil,
+	// verification uses the embedded jwk header only (RFC 9449 default).
+	TrustedRoots *x509.CertPool
+
 	now time.Time
 }
 
@@ -28,6 +38,10 @@ type Proof struct {
 	VerifiedJWT *jwt.VerifiedJWT
 	// Thumbprint is the JWK thumbprint.
 	Thumbprint string
+	// CertificateChain is the validated x5c chain (leaf first, then
+	// intermediates toward the trust anchor) when [Verifier.TrustedRoots] was
+	// set; otherwise nil.
+	CertificateChain []*x509.Certificate
 }
 
 // ValidatorOpts parameters for DPoP token validation.
@@ -67,49 +81,24 @@ func (d *Verifier) VerifyAndDecode(compact string, validator *Validator) (*Proof
 		return nil, fmt.Errorf("parsing JWT header: %w", err)
 	}
 
-	jwkRaw, ok := header["jwk"]
-	if !ok {
-		return nil, fmt.Errorf("jwk header is missing")
-	}
+	var thumbprint string
+	var handle *keyset.Handle
+	var certChain []*x509.Certificate
 
-	thumbprint, err := calculateJWKThumbprint(jwkRaw)
+	if d.TrustedRoots != nil {
+		thumbprint, handle, certChain, err = d.verifyMaterialFromX5C(header)
+	} else {
+		thumbprint, handle, err = verifyMaterialFromJWK(header)
+	}
 	if err != nil {
-		return nil, fmt.Errorf("calculating JWK thumbprint: %w", err)
+		return nil, err
 	}
 
-	// Firstly, make sure the thumbprint matches the expected one. Can fail fase
-	// if it doesn't
 	if !validator.opts.IgnoreThumbprint && thumbprint != validator.opts.ExpectedThumbprint {
 		return nil, fmt.Errorf("JWK thumbprint mismatch: got %q, want %q", thumbprint, validator.opts.ExpectedThumbprint)
 	}
 
-	// we need to make sure we have an alg for the JWK, for tink to handle it.
-	// We rely on it to validate the specified alg matches the key type.
-	alg, ok := header["alg"].(string)
-	if !ok {
-		return nil, fmt.Errorf("missing or invalid alg in header")
-	}
-
-	jwkMap, ok := jwkRaw.(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("jwk is not a map")
-	}
-
-	jwkForTink := make(map[string]any)
-	maps.Copy(jwkForTink, jwkMap)
-	jwkForTink["alg"] = alg
-
-	jwkWithAlgJSON, err := json.Marshal(jwkForTink)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling jwk with alg: %w", err)
-	}
-
-	handle, err := jwt.JWKSetToPublicKeysetHandle(fmt.Appendf(nil, `{"keys":[%s]}`, string(jwkWithAlgJSON)))
-	if err != nil {
-		return nil, fmt.Errorf("creating keyset handle from JWK: %w", err)
-	}
-
-	verifier, err := jwt.NewVerifier(handle)
+	jwtVerifier, err := jwt.NewVerifier(handle)
 	if err != nil {
 		return nil, fmt.Errorf("creating tink verifier: %w", err)
 	}
@@ -122,7 +111,7 @@ func (d *Verifier) VerifyAndDecode(compact string, validator *Validator) (*Proof
 		return nil, fmt.Errorf("creating validator: %w", err)
 	}
 
-	verifiedJWT, err := verifier.VerifyAndDecode(compact, tinkValidator)
+	verifiedJWT, err := jwtVerifier.VerifyAndDecode(compact, tinkValidator)
 	if err != nil {
 		return nil, fmt.Errorf("verifying JWT: %w", err)
 	}
@@ -183,7 +172,159 @@ func (d *Verifier) VerifyAndDecode(compact string, validator *Validator) (*Proof
 	}
 
 	return &Proof{
-		VerifiedJWT: verifiedJWT,
-		Thumbprint:  thumbprint,
+		VerifiedJWT:      verifiedJWT,
+		Thumbprint:       thumbprint,
+		CertificateChain: certChain,
 	}, nil
+}
+
+func headerAlg(header *structpb.Struct) (string, error) {
+	if !hasClaimOfKind(header, "alg", &structpb.Value{Kind: &structpb.Value_StringValue{}}) {
+		return "", fmt.Errorf("alg header is missing")
+	}
+	alg := header.GetFields()["alg"].GetStringValue()
+	if alg == "" {
+		return "", fmt.Errorf("alg header is empty")
+	}
+	return alg, nil
+}
+
+func keysetHandleFromJWKWithAlg(jwk map[string]any, alg string) (*keyset.Handle, error) {
+	jwkForTink := make(map[string]any)
+	maps.Copy(jwkForTink, jwk)
+	jwkForTink["alg"] = alg
+	jwkWithAlgJSON, err := json.Marshal(jwkForTink)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling jwk with alg: %w", err)
+	}
+	handle, err := jwt.JWKSetToPublicKeysetHandle(fmt.Appendf(nil, `{"keys":[%s]}`, string(jwkWithAlgJSON)))
+	if err != nil {
+		return nil, fmt.Errorf("creating keyset handle from JWK: %w", err)
+	}
+	return handle, nil
+}
+
+func verifyMaterialFromJWK(header *structpb.Struct) (thumbprint string, handle *keyset.Handle, err error) {
+	if !hasClaimOfKind(header, "jwk", &structpb.Value{Kind: &structpb.Value_StructValue{}}) {
+		return "", nil, fmt.Errorf("jwk header is missing")
+	}
+	jwk := header.GetFields()["jwk"].GetStructValue().AsMap()
+	if len(jwk) == 0 {
+		return "", nil, fmt.Errorf("jwk header is missing")
+	}
+
+	thumbprint, err = calculateJWKThumbprint(jwk)
+	if err != nil {
+		return "", nil, fmt.Errorf("calculating JWK thumbprint: %w", err)
+	}
+
+	alg, err := headerAlg(header)
+	if err != nil {
+		return "", nil, err
+	}
+
+	handle, err = keysetHandleFromJWKWithAlg(jwk, alg)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return thumbprint, handle, nil
+}
+
+func (d *Verifier) verifyMaterialFromX5C(header *structpb.Struct) (thumbprint string, handle *keyset.Handle, chain []*x509.Certificate, err error) {
+	if !hasClaimOfKind(header, "x5c", &structpb.Value{Kind: &structpb.Value_ListValue{}}) {
+		return "", nil, nil, fmt.Errorf("x5c header is required when Verifier.TrustedRoots is set")
+	}
+	x5c := header.GetFields()["x5c"].GetListValue().AsSlice()
+	if len(x5c) == 0 {
+		return "", nil, nil, fmt.Errorf("x5c header is missing or empty")
+	}
+
+	certChain, err := parseAndVerifyCertChain(d.TrustedRoots, x5c)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("verifying certificate chain: %w", err)
+	}
+
+	leafCert := certChain[0]
+	leafJWK, err := publicKeyToJWK(leafCert.PublicKey)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("leaf certificate public key: %w", err)
+	}
+
+	thumbprint, err = calculateJWKThumbprint(leafJWK)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("calculating JWK thumbprint: %w", err)
+	}
+
+	if hasClaimOfKind(header, "jwk", &structpb.Value{Kind: &structpb.Value_StructValue{}}) {
+		hdrJWK := header.GetFields()["jwk"].GetStructValue().AsMap()
+		if len(hdrJWK) > 0 {
+			hdrTP, err := calculateJWKThumbprint(hdrJWK)
+			if err != nil {
+				return "", nil, nil, fmt.Errorf("calculating header jwk thumbprint: %w", err)
+			}
+			if hdrTP != thumbprint {
+				return "", nil, nil, fmt.Errorf("jwk does not match x5c leaf certificate public key")
+			}
+		}
+	}
+
+	alg, err := headerAlg(header)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	handle, err = keysetHandleFromJWKWithAlg(leafJWK, alg)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("creating keyset handle from leaf certificate: %w", err)
+	}
+
+	return thumbprint, handle, certChain, nil
+}
+
+func parseAndVerifyCertChain(roots *x509.CertPool, x5c []any) ([]*x509.Certificate, error) {
+	if roots == nil {
+		return nil, fmt.Errorf("trusted roots are not set")
+	}
+
+	certs := make([]*x509.Certificate, 0, len(x5c))
+	for i, certB64 := range x5c {
+		certStr, ok := certB64.(string)
+		if !ok {
+			return nil, fmt.Errorf("x5c[%d] is not a string", i)
+		}
+
+		certDER, err := base64.StdEncoding.DecodeString(certStr)
+		if err != nil {
+			return nil, fmt.Errorf("decoding x5c[%d]: %w", i, err)
+		}
+
+		cert, err := x509.ParseCertificate(certDER)
+		if err != nil {
+			return nil, fmt.Errorf("parsing x5c[%d]: %w", i, err)
+		}
+
+		certs = append(certs, cert)
+	}
+
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates in x5c chain")
+	}
+
+	leafCert := certs[0]
+	intermediates := certs[1:]
+
+	opts := x509.VerifyOptions{
+		Intermediates: x509.NewCertPool(),
+		Roots:         roots,
+	}
+	for _, intermediate := range intermediates {
+		opts.Intermediates.AddCert(intermediate)
+	}
+
+	if _, err := leafCert.Verify(opts); err != nil {
+		return nil, fmt.Errorf("certificate chain verification failed: %w", err)
+	}
+
+	return certs, nil
 }

--- a/dpop/verifier_test.go
+++ b/dpop/verifier_test.go
@@ -4,6 +4,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
@@ -31,11 +35,11 @@ func TestDPoPVerifier_ExampleToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to parse JWT header: %v", err)
 	}
-	jwkRaw, ok := header["jwk"]
-	if !ok {
+	jwk := header.GetFields()["jwk"].GetStructValue().AsMap()
+	if len(jwk) == 0 {
 		t.Fatal("jwk header is missing")
 	}
-	expectedThumbprint, err := calculateJWKThumbprint(jwkRaw)
+	expectedThumbprint, err := calculateJWKThumbprint(jwk)
 	if err != nil {
 		t.Fatalf("failed to calculate thumbprint: %v", err)
 	}
@@ -579,4 +583,282 @@ func TestDPoPVerifier_AllowUnsetHTMHTU(t *testing.T) {
 			t.Errorf("expected htm mismatch error, got: %v", err)
 		}
 	})
+}
+
+// testLeafCertChain returns a leaf ECDSA key, leaf cert, and CA cert (leaf signed by CA).
+func testLeafCertChain(t *testing.T) (*ecdsa.PrivateKey, *x509.Certificate, *x509.Certificate) {
+	t.Helper()
+	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("CA key: %v", err)
+	}
+	caTpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTpl, caTpl, &caPriv.PublicKey, caPriv)
+	if err != nil {
+		t.Fatalf("CreateCertificate CA: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate CA: %v", err)
+	}
+
+	leafPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	leafTpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTpl, caCert, &leafPriv.PublicKey, caPriv)
+	if err != nil {
+		t.Fatalf("CreateCertificate leaf: %v", err)
+	}
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate leaf: %v", err)
+	}
+
+	return leafPriv, leafCert, caCert
+}
+
+func x5cB64Chain(leaf, ca *x509.Certificate) []string {
+	return []string{
+		base64.StdEncoding.EncodeToString(leaf.Raw),
+		base64.StdEncoding.EncodeToString(ca.Raw),
+	}
+}
+
+func TestNewSignerWithCertificateChain_MismatchedLeaf(t *testing.T) {
+	_, leafCert, caCert := testLeafCertChain(t)
+	wrongPriv := generateTestKey(t)
+	_, err := NewSignerWithCertificateChain(wrongPriv, []*x509.Certificate{leafCert, caCert})
+	if err == nil {
+		t.Fatal("expected error when signer key does not match leaf certificate")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDPoPVerifier_TrustedRoots_X5C(t *testing.T) {
+	leafPriv, leafCert, caCert := testLeafCertChain(t)
+
+	signer, err := NewSignerWithCertificateChain(leafPriv, []*x509.Certificate{leafCert, caCert})
+	if err != nil {
+		t.Fatalf("NewSignerWithCertificateChain: %v", err)
+	}
+
+	now := time.Now()
+	token, err := signer.SignAndEncode(&jwt.RawJWTOptions{
+		WithoutExpiration: true,
+		CustomClaims: map[string]any{
+			"htm": "POST",
+			"htu": "https://server.example.com/token",
+		},
+		IssuedAt: &now,
+	})
+	if err != nil {
+		t.Fatalf("SignAndEncode: %v", err)
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+
+	expectedTP, err := calculateJWKThumbprint(signer.jwk)
+	if err != nil {
+		t.Fatalf("thumbprint: %v", err)
+	}
+	val, err := NewValidator(&ValidatorOpts{ExpectedThumbprint: expectedTP})
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+
+	v := &Verifier{TrustedRoots: roots}
+	proof, err := v.VerifyAndDecode(token, val)
+	if err != nil {
+		t.Fatalf("VerifyAndDecode: %v", err)
+	}
+	if proof.Thumbprint != expectedTP {
+		t.Errorf("thumbprint: got %q want %q", proof.Thumbprint, expectedTP)
+	}
+	if proof.CertificateChain == nil {
+		t.Fatal("expected CertificateChain when using TrustedRoots")
+	}
+	if len(proof.CertificateChain) != 2 {
+		t.Fatalf("CertificateChain len: got %d want 2", len(proof.CertificateChain))
+	}
+	if !proof.CertificateChain[0].Equal(leafCert) {
+		t.Error("chain[0] does not match leaf")
+	}
+	if !proof.CertificateChain[1].Equal(caCert) {
+		t.Error("chain[1] does not match CA")
+	}
+}
+
+func TestDPoPVerifier_TrustedRoots_RequiresX5C(t *testing.T) {
+	_, _, caCert := testLeafCertChain(t)
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+
+	privKey := generateTestKey(t)
+	signer, err := NewSigner(privKey)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+
+	now := time.Now()
+	token, err := signer.SignAndEncode(&jwt.RawJWTOptions{
+		WithoutExpiration: true,
+		IssuedAt:          &now,
+	})
+	if err != nil {
+		t.Fatalf("SignAndEncode: %v", err)
+	}
+
+	val, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: mustThumbprint(t, signer.jwk),
+		IgnoreThumbprint:   true,
+	})
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+
+	v := &Verifier{TrustedRoots: roots}
+	_, err = v.VerifyAndDecode(token, val)
+	if err == nil {
+		t.Fatal("expected error when TrustedRoots is set but x5c is absent")
+	}
+	if !strings.Contains(err.Error(), "x5c header is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDPoPVerifier_TrustedRoots_WrongRoot(t *testing.T) {
+	leafPriv, leafCert, caCert := testLeafCertChain(t)
+
+	otherPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("other CA key: %v", err)
+	}
+	otherTpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(99),
+		Subject:               pkix.Name{CommonName: "other-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	otherDER, err := x509.CreateCertificate(rand.Reader, otherTpl, otherTpl, &otherPriv.PublicKey, otherPriv)
+	if err != nil {
+		t.Fatalf("other CA cert: %v", err)
+	}
+	otherCA, err := x509.ParseCertificate(otherDER)
+	if err != nil {
+		t.Fatalf("parse other CA: %v", err)
+	}
+
+	signer, err := NewSignerWithCertificateChain(leafPriv, []*x509.Certificate{leafCert, caCert})
+	if err != nil {
+		t.Fatalf("NewSignerWithCertificateChain: %v", err)
+	}
+
+	now := time.Now()
+	token, err := signer.SignAndEncode(&jwt.RawJWTOptions{
+		WithoutExpiration: true,
+		IssuedAt:          &now,
+	})
+	if err != nil {
+		t.Fatalf("SignAndEncode: %v", err)
+	}
+
+	wrongRoots := x509.NewCertPool()
+	wrongRoots.AddCert(otherCA)
+
+	val, err := NewValidator(&ValidatorOpts{
+		ExpectedThumbprint: mustThumbprint(t, signer.jwk),
+		IgnoreThumbprint:   true,
+	})
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+
+	v := &Verifier{TrustedRoots: wrongRoots}
+	_, err = v.VerifyAndDecode(token, val)
+	if err == nil {
+		t.Fatal("expected chain verification failure")
+	}
+	if !strings.Contains(err.Error(), "certificate chain verification failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDPoPVerifier_TrustedRoots_JWKMismatchesLeaf(t *testing.T) {
+	leafPriv, leafCert, caCert := testLeafCertChain(t)
+	otherPriv := generateTestKey(t)
+	otherJWK, err := publicKeyToJWK(otherPriv.Public())
+	if err != nil {
+		t.Fatalf("publicKeyToJWK: %v", err)
+	}
+
+	signer, err := NewSigner(leafPriv)
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+
+	now := time.Now()
+	rawJWT, err := jwt.NewRawJWT(&jwt.RawJWTOptions{
+		TypeHeader:        stringPtr("dpop+jwt"),
+		WithoutExpiration: true,
+		IssuedAt:          &now,
+	})
+	if err != nil {
+		t.Fatalf("NewRawJWT: %v", err)
+	}
+
+	token, err := signer.encodeWithHeaders(rawJWT, map[string]any{
+		"jwk": otherJWK,
+		"x5c": x5cB64Chain(leafCert, caCert),
+	})
+	if err != nil {
+		t.Fatalf("encodeWithHeaders: %v", err)
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(caCert)
+
+	val, err := NewValidator(&ValidatorOpts{IgnoreThumbprint: true})
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+
+	v := &Verifier{TrustedRoots: roots}
+	_, err = v.VerifyAndDecode(token, val)
+	if err == nil {
+		t.Fatal("expected jwk / x5c mismatch error")
+	}
+	if !strings.Contains(err.Error(), "jwk does not match x5c leaf") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func mustThumbprint(t *testing.T, jwk map[string]any) string {
+	t.Helper()
+	tp, err := calculateJWKThumbprint(jwk)
+	if err != nil {
+		t.Fatalf("thumbprint: %v", err)
+	}
+	return tp
 }

--- a/oauth2as/server_token.go
+++ b/oauth2as/server_token.go
@@ -55,6 +55,8 @@ type TokenRequest struct {
 	// DPoPBound indicates whether this grant is bound to a DPoP key. If true,
 	// all token requests for this grant must include a valid DPoP proof.
 	DPoPBound bool
+	// DPoPProof includes the verified DPoP proof, if present.
+	DPoPProof *dpop.Proof
 }
 
 // TokenResponse is returned by the token endpoint handler, indicating what it
@@ -160,9 +162,13 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2p
 
 	// Verify DPoP proof if present. In the code flow, we allow any thumbprint -
 	// the result is what we'll bind the grant to.
-	dpopThumbprint, err := s.verifyDPoPProof(s.config.Issuer, req, nil)
+	dpopProof, err := s.verifyDPoPProof(s.config.Issuer, req, nil)
 	if err != nil {
 		return nil, err
+	}
+	var dpopThumbprint string
+	if dpopProof != nil {
+		dpopThumbprint = dpopProof.Thumbprint
 	}
 
 	loadedGrant, err := s.getGrantFromAuthCode(ctx, treq.Code)
@@ -253,6 +259,7 @@ func (s *Server) codeToken(ctx context.Context, req *http.Request, treq *oauth2p
 		DecryptedMetadata: loadedGrant.decryptedMetadata,
 		IsRefresh:         false,
 		DPoPBound:         isDPoPBound,
+		DPoPProof:         dpopProof,
 	}
 
 	// TODO: Make TokenHandler callback optional for code exchange
@@ -339,12 +346,14 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 		storedThumbprint = *loadedGrant.additionalState.DPoPThumbprint
 	}
 
+	var dpopProof *dpop.Proof
 	if storedThumbprint != "" {
-		thumbprint, err := s.verifyDPoPProof(s.config.Issuer, req, &storedThumbprint)
+		var err error
+		dpopProof, err = s.verifyDPoPProof(s.config.Issuer, req, &storedThumbprint)
 		if err != nil {
 			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "DPoP proof key mismatch"}
 		}
-		if thumbprint == "" {
+		if dpopProof == nil || dpopProof.Thumbprint == "" {
 			return nil, &oauth2proto.TokenError{ErrorCode: oauth2proto.TokenErrorCodeInvalidGrant, Description: "DPoP proof required"}
 		}
 	}
@@ -375,6 +384,7 @@ func (s *Server) refreshToken(ctx context.Context, req *http.Request, treq *oaut
 		DecryptedMetadata: loadedGrant.decryptedMetadata,
 		IsRefresh:         true,
 		DPoPBound:         isDPoPBound,
+		DPoPProof:         dpopProof,
 	}
 	tresp, err := s.config.TokenHandler(ctx, tr)
 	if err != nil {
@@ -618,27 +628,26 @@ func verifyCodeChallenge(codeVerifier, storedCodeChallenge string) bool {
 }
 
 // verifyDPoPProof extracts and verifies the DPoP header from a request. Returns
-// the thumbprint if a valid DPoP proof is provided, empty string if no DPoP
-// header is present, or an error if the proof is invalid. The
-// expectedThumbprint parameter is optional, if it is not nil, the thumbprint
-// will be validated against it.
-func (s *Server) verifyDPoPProof(iss string, req *http.Request, expectedThumbprint *string) (thumbprint string, err error) {
+// a verified [dpop.Proof] if a valid DPoP proof is provided, nil if no DPoP
+// header is present (and none is required), or an error if the proof is invalid.
+// When expectedThumbprint is non-nil, the proof's thumbprint must match it.
+func (s *Server) verifyDPoPProof(iss string, req *http.Request, expectedThumbprint *string) (proof *dpop.Proof, err error) {
 	dpopHeader := req.Header.Get("DPoP")
 	if dpopHeader == "" {
 		if expectedThumbprint != nil {
-			return "", fmt.Errorf("DPoP header required")
+			return nil, fmt.Errorf("DPoP header required")
 		}
-		return "", nil
+		return nil, nil
 	}
 
 	if s.config.DPoPVerifier == nil {
 		slog.DebugContext(req.Context(), "DPoP proof provided but DPoP is not supported")
-		return "", nil
+		return nil, nil
 	}
 
 	issURL, err := url.Parse(iss)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse issuer: %w", err)
+		return nil, fmt.Errorf("failed to parse issuer: %w", err)
 	}
 
 	opts := &dpop.ValidatorOpts{
@@ -655,12 +664,12 @@ func (s *Server) verifyDPoPProof(iss string, req *http.Request, expectedThumbpri
 	// Verify the DPoP proof (verifier will validate HTM/HTU from request)
 	validator, err := dpop.NewValidator(opts)
 	if err != nil {
-		return "", fmt.Errorf("failed to create validator: %w", err)
+		return nil, fmt.Errorf("failed to create validator: %w", err)
 	}
 	res, err := s.config.DPoPVerifier.VerifyAndDecode(dpopHeader, validator)
 	if err != nil {
-		return "", fmt.Errorf("failed to verify DPoP proof: %w", err)
+		return nil, fmt.Errorf("failed to verify DPoP proof: %w", err)
 	}
 
-	return res.Thumbprint, nil
+	return res, nil
 }


### PR DESCRIPTION
This is non-standard, part of an experiment. The idea is to achieve device-bound proofs with some form of device verification like what is possible in RFC8705, in environments where mTLS is not possible.

DPoP proofs can be created as a "self-signed" JWT, with the certificate chain corresponding to the signing key included in the x5c header. Verifiers can be created with a series of trusted roots, if they are the x5c header presence will be enforced, and it will be checked that it corresponds to one of these roots.

Update the oauth2as package to pass the proof, for services that want to inspect the certs for logging etc.
