### PR TITLE
dpop: Fix cert verification

### DIFF
--- a/dpop/verifier.go
+++ b/dpop/verifier.go
@@ -25,7 +25,8 @@ type Verifier struct {
 	// TrustedRoots, when non-nil, requires a non-empty x5c JWT header. The leaf
 	// certificate must chain to one of these roots (per x509.Verify). The JWT
 	// signature is verified using the leaf certificate's public key. When nil,
-	// verification uses the embedded jwk header only (RFC 9449 default).
+	// verification uses the embedded jwk header only (RFC 9449 default). Any
+	// key usage will be considered valid.
 	TrustedRoots *x509.CertPool
 
 	now time.Time
@@ -316,6 +317,7 @@ func parseAndVerifyCertChain(roots *x509.CertPool, x5c []any) ([]*x509.Certifica
 	opts := x509.VerifyOptions{
 		Intermediates: x509.NewCertPool(),
 		Roots:         roots,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 	for _, intermediate := range intermediates {
 		opts.Intermediates.AddCert(intermediate)

--- a/dpop/verifier_test.go
+++ b/dpop/verifier_test.go
@@ -616,6 +616,10 @@ func testLeafCertChain(t *testing.T) (*ecdsa.PrivateKey, *x509.Certificate, *x50
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(24 * time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
+		// Client auth only — not TLS server auth. Matches many real issuing
+		// templates and would fail x509.Verify with default KeyUsages unless we
+		// pass ExtKeyUsageAny (see crypto/x509.VerifyOptions.KeyUsages).
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}
 	leafDER, err := x509.CreateCertificate(rand.Reader, leafTpl, caCert, &leafPriv.PublicKey, caPriv)
 	if err != nil {


### PR DESCRIPTION
By default the verifier requires a usage of server auth. We don't care here what the usage is, so allow any.