### PR TITLE
jwt: Add remote keysource package

### DIFF
--- a/jwt/keyset.go
+++ b/jwt/keyset.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto/rsa"
 	"encoding/json/jsontext"
 	jsonv2 "encoding/json/v2"
@@ -15,6 +16,20 @@ const maxJWKSBytes = 1 << 20 // 1 MiB
 // KeySet is an opaque set of public verification keys.
 type KeySet struct {
 	jwks jose.JSONWebKeySet
+}
+
+// KeySetSource supplies public verification keys. Implementations may fetch
+// and cache keys, or return a fixed local key set.
+type KeySetSource interface {
+	KeySet(context.Context) (*KeySet, error)
+}
+
+// KeySetSourceFunc adapts a function to a [KeySetSource].
+type KeySetSourceFunc func(context.Context) (*KeySet, error)
+
+// KeySet returns the key set provided by f.
+func (f KeySetSourceFunc) KeySet(ctx context.Context) (*KeySet, error) {
+	return f(ctx)
 }
 
 // MarshalJSON encodes the key set as a JWKS document.

--- a/jwt/remotejwks/doc.go
+++ b/jwt/remotejwks/doc.go
@@ -1,0 +1,7 @@
+// Package remotejwks fetches and caches a JWKS from an HTTP URL.
+//
+// [Source] represents one jwks_uri. Callers that map identifiers to URLs,
+// such as OAuth clients authenticating with private_key_jwt, should retain one
+// Source per URL. Host allowlists and other SSRF controls are the caller's
+// responsibility.
+package remotejwks

--- a/jwt/remotejwks/source.go
+++ b/jwt/remotejwks/source.go
@@ -1,0 +1,154 @@
+package remotejwks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"lds.li/oauth2ext/internal"
+	"lds.li/oauth2ext/jwt"
+)
+
+const (
+	// DefaultCacheDuration is used when [Source.CacheDuration] is zero.
+	DefaultCacheDuration = 10 * time.Minute
+	maxJWKSBytes         = 1 << 20 // 1 MiB
+)
+
+var validJWKSContentTypes = []string{
+	"application/json",
+	"application/jwk-set+json",
+}
+
+// Source fetches and TTL-caches a JWKS from URL.
+//
+// Fields must not be modified after the first call to [Source.KeySet] or
+// [Source.JWKS].
+type Source struct {
+	// URL is the jwks_uri to GET. Required.
+	URL string
+	// HTTPClient is used when the context does not carry oauth2.HTTPClient.
+	HTTPClient *http.Client
+	// CacheDuration is how long a successful fetch is reused. Defaults to
+	// [DefaultCacheDuration].
+	CacheDuration time.Duration
+	// StaleOnError returns the last successful key set when a refresh fails.
+	// Without it, a failed refresh returns the fetch error even if older keys
+	// are cached.
+	StaleOnError bool
+
+	mu          sync.Mutex
+	lastFetched time.Time
+	raw         []byte
+	parsed      *jwt.KeySet
+	now         func() time.Time
+}
+
+var _ jwt.KeySetSource = (*Source)(nil)
+
+// KeySet returns the cached key set, fetching it when the TTL has expired.
+func (s *Source) KeySet(ctx context.Context) (*jwt.KeySet, error) {
+	parsed, _, err := s.get(ctx)
+	return parsed, err
+}
+
+// JWKS returns a copy of the cached JWKS document, fetching it when the TTL
+// has expired.
+func (s *Source) JWKS(ctx context.Context) ([]byte, error) {
+	_, raw, err := s.get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.Clone(raw), nil
+}
+
+func (s *Source) get(ctx context.Context) (*jwt.KeySet, []byte, error) {
+	if s == nil {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: source is required")
+	}
+	if s.URL == "" {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: URL is required")
+	}
+
+	cacheFor := s.CacheDuration
+	if cacheFor == 0 {
+		cacheFor = DefaultCacheDuration
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.nowTime()
+	if s.freshLocked(now, cacheFor) {
+		return s.parsed, s.raw, nil
+	}
+
+	raw, parsed, err := s.fetch(ctx)
+	if err != nil {
+		if s.StaleOnError && s.parsed != nil {
+			return s.parsed, s.raw, nil
+		}
+		return nil, nil, err
+	}
+	s.raw = raw
+	s.parsed = parsed
+	s.lastFetched = now
+	return parsed, raw, nil
+}
+
+func (s *Source) freshLocked(now time.Time, cacheFor time.Duration) bool {
+	return s.parsed != nil && !s.lastFetched.IsZero() && now.Sub(s.lastFetched) < cacheFor
+}
+
+func (s *Source) nowTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+func (s *Source) fetch(ctx context.Context) ([]byte, *jwt.KeySet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: creating request for %s: %w", s.URL, err)
+	}
+	res, err := internal.HTTPClientFromContext(ctx, s.HTTPClient).Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: fetching JWKS from %s: %w", s.URL, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: fetching JWKS from %s: expected status %d, got %d", s.URL, http.StatusOK, res.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(res.Header.Get("Content-Type"))
+	if err != nil || !slices.Contains(validJWKSContentTypes, mediaType) {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: fetching JWKS from %s: expected content type %s, got %s", s.URL, strings.Join(validJWKSContentTypes, ", "), res.Header.Get("Content-Type"))
+	}
+	body, err := readBounded(res.Body, maxJWKSBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: reading JWKS from %s: %w", s.URL, err)
+	}
+	parsed, err := jwt.ParseJWKSet(body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("jwt/remotejwks: parsing JWKS from %s: %w", s.URL, err)
+	}
+	return body, parsed, nil
+}
+
+func readBounded(r io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("%w: response exceeds %d byte limit", jwt.ErrSizeLimit, limit)
+	}
+	return body, nil
+}

--- a/jwt/remotejwks/source_test.go
+++ b/jwt/remotejwks/source_test.go
@@ -1,0 +1,255 @@
+package remotejwks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/jwttest"
+)
+
+func TestKeySetFetchesAndCaches(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/jwk-set+json; charset=utf-8")
+		_, _ = w.Write(signer.JWKS())
+	}))
+	t.Cleanup(srv.Close)
+
+	ks := &Source{URL: srv.URL, CacheDuration: time.Minute}
+	first, err := ks.KeySet(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := ks.KeySet(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("cached Get returned a different key set")
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("fetches: got %d, want 1", hits.Load())
+	}
+}
+
+func TestKeySetRefreshesAfterTTL(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	var hits atomic.Int64
+	srv := httptest.NewServer(jwksHandler(&hits, signer.JWKS()))
+	t.Cleanup(srv.Close)
+
+	now := time.Unix(1_700_000_000, 0)
+	ks := &Source{
+		URL:           srv.URL,
+		CacheDuration: time.Minute,
+		now:           func() time.Time { return now },
+	}
+	if _, err := ks.KeySet(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Minute)
+	if _, err := ks.KeySet(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if hits.Load() != 2 {
+		t.Fatalf("fetches: got %d, want 2", hits.Load())
+	}
+}
+
+func TestKeySetSingleflight(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	var hits atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		close(started)
+		<-release
+		w.Header().Set("Content-Type", "application/jwk-set+json")
+		_, _ = w.Write(signer.JWKS())
+	}))
+	t.Cleanup(srv.Close)
+
+	ks := &Source{URL: srv.URL}
+	var wg sync.WaitGroup
+	errCh := make(chan error, 8)
+	for range 8 {
+		wg.Go(func() {
+			_, err := ks.KeySet(t.Context())
+			errCh <- err
+		})
+	}
+	<-started
+	close(release)
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if hits.Load() != 1 {
+		t.Fatalf("fetches: got %d, want 1", hits.Load())
+	}
+}
+
+func TestJWKSReturnsCopy(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	srv := httptest.NewServer(jwksHandler(nil, signer.JWKS()))
+	t.Cleanup(srv.Close)
+
+	ks := &Source{URL: srv.URL}
+	first, err := ks.JWKS(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := bytes.Clone(first)
+	first[0] ^= 0xff
+	second, err := ks.JWKS(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(second, want) {
+		t.Fatal("mutating returned JWKS changed cache")
+	}
+}
+
+func TestStaleOnError(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	var fail atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, "nope", http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/jwk-set+json")
+		_, _ = w.Write(signer.JWKS())
+	}))
+	t.Cleanup(srv.Close)
+
+	now := time.Unix(1_700_000_000, 0)
+	ks := &Source{
+		URL:           srv.URL,
+		CacheDuration: time.Minute,
+		StaleOnError:  true,
+		now:           func() time.Time { return now },
+	}
+	first, err := ks.KeySet(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fail.Store(true)
+	now = now.Add(time.Minute)
+	got, err := ks.KeySet(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != first {
+		t.Fatal("stale Get returned a different key set")
+	}
+}
+
+func TestKeySetRefreshErrorWithoutStale(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	var fail atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, "nope", http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/jwk-set+json")
+		_, _ = w.Write(signer.JWKS())
+	}))
+	t.Cleanup(srv.Close)
+
+	now := time.Unix(1_700_000_000, 0)
+	ks := &Source{
+		URL:           srv.URL,
+		CacheDuration: time.Minute,
+		now:           func() time.Time { return now },
+	}
+	if _, err := ks.KeySet(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	fail.Store(true)
+	now = now.Add(time.Minute)
+	if _, err := ks.KeySet(t.Context()); err == nil {
+		t.Fatal("expected refresh error")
+	}
+}
+
+func TestKeySetRejectsEmptyURL(t *testing.T) {
+	if _, err := (&Source{}).KeySet(t.Context()); err == nil {
+		t.Fatal("empty URL accepted")
+	}
+}
+
+func TestKeySetRejectsWrongContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	if _, err := (&Source{URL: srv.URL}).KeySet(t.Context()); err == nil {
+		t.Fatal("expected content type error")
+	}
+}
+
+func TestKeySetRejectsOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(bytes.Repeat([]byte{' '}, maxJWKSBytes+1))
+	}))
+	t.Cleanup(srv.Close)
+	_, err := (&Source{URL: srv.URL}).KeySet(t.Context())
+	if err == nil || !errors.Is(err, jwt.ErrSizeLimit) {
+		t.Fatalf("error: got %v, want ErrSizeLimit", err)
+	}
+}
+
+func TestKeySetRejectsInvalidJWKS(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	_, err := (&Source{URL: srv.URL}).KeySet(t.Context())
+	if err == nil || !errors.Is(err, jwt.ErrKey) {
+		t.Fatalf("error: got %v, want ErrKey", err)
+	}
+}
+
+func TestKeySetUsesContextHTTPClient(t *testing.T) {
+	signer := jwttest.NewSigner(t)
+	srv := httptest.NewTLSServer(jwksHandler(nil, signer.JWKS()))
+	t.Cleanup(srv.Close)
+
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, srv.Client())
+	if _, err := (&Source{URL: srv.URL}).KeySet(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func jwksHandler(hits *atomic.Int64, body []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if hits != nil {
+			hits.Add(1)
+		}
+		w.Header().Set("Content-Type", "application/jwk-set+json")
+		_, _ = w.Write(body)
+	}
+}

--- a/provider/discovery.go
+++ b/provider/discovery.go
@@ -7,18 +7,42 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"slices"
 	"strings"
 	"time"
 
 	"lds.li/oauth2ext/internal"
 	"lds.li/oauth2ext/jwt"
+	"lds.li/oauth2ext/jwt/remotejwks"
 )
 
-func DiscoverOIDCProvider(ctx context.Context, issuer string) (*Provider, error) {
+// Option configures a discovered provider.
+type Option func(*Provider) error
+
+// WithVerificationKeys overrides the key source advertised by discovery. The
+// source is used from initial discovery onwards, while discovery metadata and
+// issuer validation still take place.
+func WithVerificationKeys(source jwt.KeySetSource) Option {
+	return func(p *Provider) error {
+		if source == nil {
+			return fmt.Errorf("provider verification key source is required")
+		}
+		p.VerificationKeys = source
+		return nil
+	}
+}
+
+func DiscoverOIDCProvider(ctx context.Context, issuer string, options ...Option) (*Provider, error) {
 	p := &Provider{
 		oidcDiscoveryURL: strings.TrimSuffix(issuer, "/") + "/.well-known/openid-configuration",
 		discoveryIssuer:  issuer,
+	}
+	for _, option := range options {
+		if option == nil {
+			return nil, fmt.Errorf("provider option is nil")
+		}
+		if err := option(p); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := p.refreshIfNeeded(ctx); err != nil {
@@ -26,11 +50,6 @@ func DiscoverOIDCProvider(ctx context.Context, issuer string) (*Provider, error)
 	}
 
 	return p, nil
-}
-
-var validJWKSContentTypes = []string{
-	"application/json",
-	"application/jwk-set+json",
 }
 
 const maxProviderResponseBytes = 1 << 20
@@ -90,39 +109,35 @@ func (p *Provider) refreshIfNeeded(ctx context.Context) error {
 		return fmt.Errorf("provider metadata is required")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, md.jwksuri(), nil)
-	if err != nil {
-		return fmt.Errorf("creating request for %s: %w", md.jwksuri(), err)
+	p.cacheMu.RLock()
+	override := p.VerificationKeys
+	keys := p.keys
+	p.cacheMu.RUnlock()
+	if override != nil {
+		keys = override
+	} else {
+		jwksURI := md.jwksuri()
+		current, ok := keys.(*remotejwks.Source)
+		if !ok || current.URL != jwksURI {
+			keys = &remotejwks.Source{
+				URL:           jwksURI,
+				HTTPClient:    p.HTTPClient,
+				CacheDuration: cacheFor,
+			}
+		}
 	}
-	req = req.WithContext(ctx)
-	res, err := internal.HTTPClientFromContext(ctx, p.HTTPClient).Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to get keys from %s: %v", md.jwksuri(), err)
+	if keys == nil {
+		return fmt.Errorf("provider has no verification keys")
 	}
-	if res.StatusCode != http.StatusOK {
-		_ = res.Body.Close()
-		return fmt.Errorf("expected status %d, got: %d", http.StatusOK, res.StatusCode)
-	}
-	mediaType, _, err := mime.ParseMediaType(res.Header.Get("Content-Type"))
-	if err != nil || !slices.Contains(validJWKSContentTypes, mediaType) {
-		_ = res.Body.Close()
-		return fmt.Errorf("expected content type %s, got: %s", strings.Join(validJWKSContentTypes, ", "), res.Header.Get("Content-Type"))
-	}
-	jwksb, err := readBounded(res.Body, maxProviderResponseBytes)
-	_ = res.Body.Close()
-	if err != nil {
-		return fmt.Errorf("reading JWKS body: %w", err)
-	}
-
-	keySet, err := jwt.ParseJWKSet(jwksb)
-	if err != nil {
-		return fmt.Errorf("creating key set from JWKS: %w", err)
+	if _, err := keys.KeySet(ctx); err != nil {
+		return fmt.Errorf("getting provider verification keys: %w", err)
 	}
 
 	p.cacheMu.Lock()
 	p.Metadata = md
-	p.cachedJWKS = jwksb
-	p.cachedKeySet = keySet
+	if p.VerificationKeys == nil {
+		p.keys = keys
+	}
 	p.cacheLastFetched = time.Now()
 	p.cacheMu.Unlock()
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	jsonv2 "encoding/json/v2"
 	"fmt"
@@ -23,12 +22,14 @@ type Provider struct {
 	Metadata      Metadata
 	HTTPClient    *http.Client
 	CacheDuration time.Duration
+	// VerificationKeys overrides the key source advertised by discovery. It
+	// must not be modified after the provider is first used.
+	VerificationKeys jwt.KeySetSource
 
 	refreshMu        sync.Mutex
 	cacheMu          sync.RWMutex
 	cacheLastFetched time.Time
-	cachedJWKS       []byte
-	cachedKeySet     *jwt.KeySet
+	keys             jwt.KeySetSource
 
 	oidcDiscoveryURL string
 	discoveryIssuer  string
@@ -100,8 +101,19 @@ func (p *Provider) JWKS(ctx context.Context) ([]byte, error) {
 	if err := p.refreshIfNeeded(ctx); err != nil {
 		return nil, err
 	}
-	_, state := p.snapshot()
-	return bytes.Clone(state.jwks), nil
+	_, keys := p.snapshot()
+	if keys == nil {
+		return nil, fmt.Errorf("provider has no verification keys")
+	}
+	keySet, err := keys.KeySet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	encoded, err := jsonv2.Marshal(keySet)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling provider verification keys: %w", err)
+	}
+	return encoded, nil
 }
 
 // VerifyJWT verifies a compact JWT against the provider JWKS and policy.
@@ -112,13 +124,17 @@ func (p *Provider) VerifyJWT(ctx context.Context, compact string, policy jwt.Val
 	if err := p.refreshIfNeeded(ctx); err != nil {
 		return nil, err
 	}
-	md, state := p.snapshot()
-	if md == nil || state.keySet == nil {
+	md, keys := p.snapshot()
+	if md == nil || keys == nil {
 		return nil, fmt.Errorf("provider has no verification keys")
+	}
+	keySet, err := keys.KeySet(ctx)
+	if err != nil {
+		return nil, err
 	}
 	policy.ExpectedIssuer = md.issuer()
 	policy.IgnoreIssuer = false
-	return state.keySet.VerifyJWT(compact, policy)
+	return keySet.VerifyJWT(compact, policy)
 }
 
 func algorithmsFromMetadata(algs []string) []jwt.Algorithm {
@@ -136,15 +152,17 @@ func algorithmsFromMetadata(algs []string) []jwt.Algorithm {
 	return out
 }
 
-type cachedState struct {
-	jwks   []byte
-	keySet *jwt.KeySet
-}
-
-func (p *Provider) snapshot() (Metadata, cachedState) {
+func (p *Provider) snapshot() (Metadata, jwt.KeySetSource) {
 	p.cacheMu.RLock()
 	defer p.cacheMu.RUnlock()
-	return p.Metadata, cachedState{jwks: p.cachedJWKS, keySet: p.cachedKeySet}
+	return p.Metadata, p.keySourceLocked()
+}
+
+func (p *Provider) keySourceLocked() jwt.KeySetSource {
+	if p.VerificationKeys != nil {
+		return p.VerificationKeys
+	}
+	return p.keys
 }
 
 // Userinfo will use the token source to query the userinfo endpoint of the

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -189,6 +189,98 @@ func TestJWKSReturnsCopy(t *testing.T) {
 	}
 }
 
+func TestDiscoveredProviderUsesVerificationKeyOverride(t *testing.T) {
+	local := jwttest.NewSigner(t)
+	var discoveryRequests atomic.Int64
+	var jwksRequests atomic.Int64
+
+	svr := httptest.NewTLSServer(nil)
+	t.Cleanup(svr.Close)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		discoveryRequests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&OIDCProviderMetadata{
+			Issuer:                           svr.URL,
+			JWKSURI:                          svr.URL + "/jwks",
+			IDTokenSigningAlgValuesSupported: []string{"ES256"},
+		})
+	})
+	mux.HandleFunc("GET /jwks", func(w http.ResponseWriter, r *http.Request) {
+		jwksRequests.Add(1)
+		http.Error(w, "must not be fetched", http.StatusInternalServerError)
+	})
+	svr.Config.Handler = mux
+
+	keys, err := jwt.ParseJWKSet(local.JWKS())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sourceCalls atomic.Int64
+	source := jwt.KeySetSourceFunc(func(context.Context) (*jwt.KeySet, error) {
+		sourceCalls.Add(1)
+		return keys, nil
+	})
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, svr.Client())
+	p, err := DiscoverOIDCProvider(ctx, svr.URL, WithVerificationKeys(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.CacheDuration = -1 // Force metadata refreshes during verification.
+
+	now := time.Now()
+	compact, err := local.SignClaims(map[string]any{
+		"iss": svr.URL,
+		"sub": "subject",
+		"aud": "client",
+		"iat": now.Unix(),
+		"exp": now.Add(time.Hour).Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := jwt.ValidationPolicy{
+		ExpectedAudiences: []string{"client"},
+		RequireIssuedAt:   true,
+		AllowedAlgorithms: []jwt.Algorithm{jwt.ES256},
+	}
+	if _, err := p.VerifyJWT(ctx, compact, policy); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.VerifyJWT(ctx, compact, policy); err != nil {
+		t.Fatal(err)
+	}
+	if got := jwksRequests.Load(); got != 0 {
+		t.Fatalf("JWKS requests = %d, want 0", got)
+	}
+	if got := discoveryRequests.Load(); got < 3 {
+		t.Fatalf("discovery requests = %d, want at least 3", got)
+	}
+	if got := sourceCalls.Load(); got < 3 {
+		t.Fatalf("source calls = %d, want at least 3", got)
+	}
+
+	first, err := p.JWKS(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := bytes.Clone(first)
+	first[0] ^= 0xff
+	second, err := p.JWKS(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(second, want) {
+		t.Fatal("mutating returned JWKS changed provider result")
+	}
+}
+
+func TestWithVerificationKeysRejectsNilSource(t *testing.T) {
+	if _, err := DiscoverOIDCProvider(t.Context(), "https://issuer.example", WithVerificationKeys(nil)); err == nil {
+		t.Fatal("expected nil verification key source error")
+	}
+}
+
 func TestUserinfo(t *testing.T) {
 	type userinforClaims struct {
 		Subject string `json:"sub"`


### PR DESCRIPTION
Looking at jwt client creds, a remote JWKS looks like a useful abstration. Add a package for a remote JWKS, and consume it in the provider.