### PR TITLE
middleware: Allow explicit login/logout, optional 401 for Ajax requests.

### DIFF
--- a/middleware/idsso_middleware.go
+++ b/middleware/idsso_middleware.go
@@ -54,6 +54,11 @@ type IDSSOHandler[IDClaims any] struct {
 	// here if the return to URL was not tracked or login was triggered from a
 	// non-GET method request.
 	BaseURL string
+	// AllowUnauthenticated, if true, lets requests without a session reach the
+	// wrapped handler without ID claims in context. OAuth callbacks and
+	// ServeLogin still run the auth code flow. Authorization remains the app's
+	// responsibility.
+	AllowUnauthenticated bool
 }
 
 // NewIDSSOHandlerFromDiscovery constructs a handler by discovering the
@@ -153,8 +158,13 @@ func (h *IDSSOHandler[IDClaims]) Wrap(next http.Handler) http.Handler {
 			return
 		}
 
+		if h.AllowUnauthenticated {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Not authenticated. Kick off an auth flow.
-		redirectURL, err := h.startAuthentication(r, session)
+		redirectURL, err := h.prepareLogin(r, session, "")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -167,6 +177,71 @@ func (h *IDSSOHandler[IDClaims]) Wrap(next http.Handler) http.Handler {
 
 		http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	})
+}
+
+// ServeLogin starts the OIDC authorization code flow and redirects to the IdP.
+// returnTo must be a path on this application (for example "/dashboard" or
+// "/items?id=1"). If returnTo is empty, GET requests use the current request
+// path and query; other methods leave the post-login destination to BaseURL or
+// "/" when the callback completes.
+func (h *IDSSOHandler[IDClaims]) ServeLogin(w http.ResponseWriter, r *http.Request, returnTo string) {
+	if h.SessionStore == nil {
+		slog.ErrorContext(r.Context(), "Uninitialized session store", baseLogAttr)
+		http.Error(w, "Uninitialized session store", http.StatusInternalServerError)
+		return
+	}
+	if h.Verifier == nil {
+		slog.ErrorContext(r.Context(), "Uninitialized verifier", baseLogAttr)
+		http.Error(w, "Uninitialized verifier", http.StatusInternalServerError)
+		return
+	}
+	session, err := h.SessionStore.GetOIDCSession(r)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "Failed to get session", baseLogAttr, errAttr(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	redirectURL, err := h.prepareLogin(r, session, returnTo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := h.SessionStore.SaveOIDCSession(w, r, session); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+}
+
+// ServeLogout clears the OIDC session (tokens and in-flight login state),
+// persists the updated session, and redirects the client. The returnTo
+// parameter follows the same rules as ServeLogin: it must be a path on this
+// application when non-empty; if empty, GET requests use the current request
+// path and query; other methods redirect to BaseURL or "/" after logout.
+func (h *IDSSOHandler[IDClaims]) ServeLogout(w http.ResponseWriter, r *http.Request, returnTo string) {
+	if h.SessionStore == nil {
+		slog.ErrorContext(r.Context(), "Uninitialized session store", baseLogAttr)
+		http.Error(w, "Uninitialized session store", http.StatusInternalServerError)
+		return
+	}
+	if h.Verifier == nil {
+		slog.ErrorContext(r.Context(), "Uninitialized verifier", baseLogAttr)
+		http.Error(w, "Uninitialized verifier", http.StatusInternalServerError)
+		return
+	}
+	session, err := h.SessionStore.GetOIDCSession(r)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "Failed to get session", baseLogAttr, errAttr(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	session.Token = nil
+	session.Logins = nil
+	if err := h.SessionStore.SaveOIDCSession(w, r, session); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, resolveReturnTo(returnToFromRequest(r, returnTo), h.BaseURL), http.StatusSeeOther)
 }
 
 // authenticateExisting returns (token, idClaims, nil) if the user is
@@ -295,15 +370,29 @@ func (h *IDSSOHandler[IDClaims]) authenticateCallback(r *http.Request, session *
 	return returnTo, nil
 }
 
-func (h *IDSSOHandler[IDClaims]) startAuthentication(r *http.Request, session *SessionData) (string, error) {
+// returnToFromRequest resolves the in-app redirect target stored for the OAuth
+// callback. If the result is empty, authenticateCallback and ServeLogout apply
+// BaseURL or "/".
+func returnToFromRequest(r *http.Request, explicitReturnTo string) string {
+	switch {
+	case explicitReturnTo != "":
+		return sanitizeReturnTo(explicitReturnTo)
+	case r.Method == http.MethodGet:
+		return sanitizeReturnTo(r.URL.RequestURI())
+	default:
+		return ""
+	}
+}
+
+func (h *IDSSOHandler[IDClaims]) prepareLogin(r *http.Request, session *SessionData, explicitReturnTo string) (string, error) {
 	session.Token = nil
 
 	var (
 		state         = rand.Text()
 		nonce         = rand.Text()
 		pkceChallenge string
-		returnTo      string
 	)
+	returnTo := returnToFromRequest(r, explicitReturnTo)
 
 	opts := append(slices.Clone(h.AuthCodeOptions), oauth2.SetAuthURLParam("nonce", nonce))
 	if h.Provider != nil && slices.Contains(h.Provider.CodeChallengeMethodsSupported(), provider.CodeChallengeMethodS256) {
@@ -311,9 +400,6 @@ func (h *IDSSOHandler[IDClaims]) startAuthentication(r *http.Request, session *S
 		opts = append(opts, oauth2.S256ChallengeOption(pkceChallenge))
 	}
 
-	if r.Method == http.MethodGet {
-		returnTo = sanitizeReturnTo(r.URL.RequestURI())
-	}
 	session.Logins = append(session.Logins, SessionDataLogin{
 		State:         state,
 		Nonce:         nonce,

--- a/middleware/idsso_middleware.go
+++ b/middleware/idsso_middleware.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -59,6 +60,9 @@ type IDSSOHandler[IDClaims any] struct {
 	// ServeLogin still run the auth code flow. Authorization remains the app's
 	// responsibility.
 	AllowUnauthenticated bool
+	// AJAXUnauth401, if true, will return a 401 Unauthorized response for AJAX
+	// requests instead of redirecting to the login page.
+	AJAXUnauth401 bool
 }
 
 // NewIDSSOHandlerFromDiscovery constructs a handler by discovering the
@@ -160,6 +164,10 @@ func (h *IDSSOHandler[IDClaims]) Wrap(next http.Handler) http.Handler {
 
 		if h.AllowUnauthenticated {
 			next.ServeHTTP(w, r)
+			return
+		}
+		if h.AJAXUnauth401 && isAJAXRequest(r) {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
 
@@ -420,6 +428,13 @@ func (h *IDSSOHandler[IDClaims]) getOAuth2Config() (oauth2.Config, error) {
 		return oauth2.Config{}, fmt.Errorf("no OAuth2Config provided")
 	}
 	return *h.OAuth2Config, nil
+}
+
+func isAJAXRequest(r *http.Request) bool {
+	if strings.EqualFold(r.Header.Get("X-Requested-With"), "XMLHttpRequest") {
+		return true
+	}
+	return strings.Contains(strings.ToLower(r.Header.Get("Accept")), "application/json")
 }
 
 type contextData struct {

--- a/middleware/idsso_middleware_test.go
+++ b/middleware/idsso_middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -34,6 +35,16 @@ func (v *rejectingIDTokenVerifier) Verify(context.Context, string, claims.IDToke
 func (v *rejectingIDTokenVerifier) VerifyTokenResponse(context.Context, *oauth2.Token, claims.IDTokenValidationInput) (struct{}, error) {
 	v.calls++
 	return struct{}{}, errors.New("rejected")
+}
+
+type unusedIDVerifier struct{}
+
+func (unusedIDVerifier) Verify(context.Context, string, claims.IDTokenValidationInput) (*claims.VerifiedID, error) {
+	return nil, errors.New("unused")
+}
+
+func (unusedIDVerifier) VerifyTokenResponse(context.Context, *oauth2.Token, claims.IDTokenValidationInput) (*claims.VerifiedID, error) {
+	return nil, errors.New("unused")
 }
 
 // mockOIDCServer mocks out just enough of an OIDC server for tests. It accepts
@@ -374,6 +385,185 @@ func TestContext(t *testing.T) {
 
 	if gotSub != "valid-subject" {
 		t.Errorf("want jwt sub valid-subject, got: %s", gotSub)
+	}
+}
+
+type memSessStore struct {
+	mu sync.Mutex
+	s  *SessionData
+}
+
+func (m *memSessStore) GetOIDCSession(r *http.Request) (*SessionData, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := SessionData{}
+	if m.s != nil {
+		out.Token = m.s.Token
+		if m.s.Logins != nil {
+			out.Logins = slices.Clone(m.s.Logins)
+		}
+	}
+	return &out, nil
+}
+
+func (m *memSessStore) SaveOIDCSession(w http.ResponseWriter, r *http.Request, d *SessionData) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if d == nil {
+		m.s = nil
+		return nil
+	}
+	cp := *d
+	if d.Logins != nil {
+		cp.Logins = slices.Clone(d.Logins)
+	}
+	m.s = &cp
+	return nil
+}
+
+func TestServeLogout_clearsSessionAndRedirects(t *testing.T) {
+	store := &memSessStore{}
+	store.mu.Lock()
+	store.s = &SessionData{
+		Logins: []SessionDataLogin{{State: "pending", Expires: int(time.Now().Add(time.Hour).Unix())}},
+	}
+	store.mu.Unlock()
+
+	h := IDSSOHandler[*claims.VerifiedID]{
+		SessionStore: store,
+		Verifier:     unusedIDVerifier{},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/logout", nil)
+	h.ServeLogout(rr, req, "")
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("code %d", rr.Code)
+	}
+	if got := rr.Header().Get("Location"); got != "/" {
+		t.Fatalf("Location = %q, want /", got)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.s == nil {
+		t.Fatal("nil session after logout")
+	}
+	if store.s.Token != nil || len(store.s.Logins) != 0 {
+		t.Fatalf("want cleared session, got token=%v logins=%d", store.s.Token, len(store.s.Logins))
+	}
+}
+
+func TestServeLogout_redirectExplicitReturnTo(t *testing.T) {
+	store := &memSessStore{}
+	h := IDSSOHandler[*claims.VerifiedID]{
+		SessionStore: store,
+		Verifier:     unusedIDVerifier{},
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+	h.ServeLogout(rr, req, "/goodbye")
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("code %d", rr.Code)
+	}
+	if got := rr.Header().Get("Location"); got != "/goodbye" {
+		t.Fatalf("Location = %q", got)
+	}
+}
+
+func TestMiddleware_AllowUnauthenticated(t *testing.T) {
+	oidcServer, oidcHTTPServer := startMockOIDCServer(t)
+
+	httpServer := httptest.NewTLSServer(nil)
+	t.Cleanup(httpServer.Close)
+
+	oidcServer.validClientID = "valid-client-id"
+	oidcServer.validClientSecret = "valid-client-secret"
+	oidcServer.validRedirectURL = fmt.Sprintf("%s/callback", httpServer.URL)
+	oidcServer.claims = map[string]any{
+		"sub": "valid-subject",
+	}
+
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, oidcHTTPServer.Client())
+	handler, err := NewFromDiscovery(ctx, &memSessStore{}, oidcServer.baseURL, oidcServer.validClientID, oidcServer.validClientSecret, oidcServer.validRedirectURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.AllowUnauthenticated = true
+
+	protected := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := handler.IDClaimsFromContext(r.Context()); ok {
+			http.Error(w, "unexpected claims", http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte("anonymous"))
+	})
+
+	httpServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(context.WithValue(r.Context(), oauth2.HTTPClient, oidcHTTPServer.Client()))
+		handler.Wrap(protected).ServeHTTP(w, r)
+	})
+
+	client := httpServer.Client()
+	resp, err := client.Get(httpServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.StatusCode, body)
+	}
+	if string(body) != "anonymous" {
+		t.Fatalf("body = %q, want anonymous", body)
+	}
+}
+
+func TestServeLogin_storesReturnToAndRedirects(t *testing.T) {
+	oidcServer, oidcHTTPServer := startMockOIDCServer(t)
+	store := &memSessStore{}
+
+	httpServer := httptest.NewTLSServer(nil)
+	t.Cleanup(httpServer.Close)
+
+	oidcServer.validClientID = "valid-client-id"
+	oidcServer.validClientSecret = "valid-client-secret"
+	oidcServer.validRedirectURL = fmt.Sprintf("%s/callback", httpServer.URL)
+	oidcServer.claims = map[string]any{
+		"sub": "valid-subject",
+	}
+
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, oidcHTTPServer.Client())
+	handler, err := NewFromDiscovery(ctx, store, oidcServer.baseURL, oidcServer.validClientID, oidcServer.validClientSecret, oidcServer.validRedirectURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req = req.WithContext(context.WithValue(req.Context(), oauth2.HTTPClient, oidcHTTPServer.Client()))
+	handler.ServeLogin(rr, req, "/after")
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("status %d", rr.Code)
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, oidcServer.baseURL+"/auth") {
+		t.Fatalf("Location = %q", loc)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.s == nil || len(store.s.Logins) != 1 {
+		t.Fatalf("logins = %v", store.s)
+	}
+	if got := store.s.Logins[0].ReturnTo; got != "/after" {
+		t.Fatalf("ReturnTo = %q", got)
 	}
 }
 

--- a/middleware/idsso_middleware_test.go
+++ b/middleware/idsso_middleware_test.go
@@ -524,6 +524,48 @@ func TestMiddleware_AllowUnauthenticated(t *testing.T) {
 	}
 }
 
+func TestMiddleware_AJAXUnauth401(t *testing.T) {
+	oidcServer, oidcHTTPServer := startMockOIDCServer(t)
+
+	httpServer := httptest.NewTLSServer(nil)
+	t.Cleanup(httpServer.Close)
+
+	oidcServer.validClientID = "valid-client-id"
+	oidcServer.validClientSecret = "valid-client-secret"
+	oidcServer.validRedirectURL = fmt.Sprintf("%s/callback", httpServer.URL)
+	oidcServer.claims = map[string]any{
+		"sub": "valid-subject",
+	}
+
+	ctx := context.WithValue(t.Context(), oauth2.HTTPClient, oidcHTTPServer.Client())
+	handler, err := NewFromDiscovery(ctx, &memSessStore{}, oidcServer.baseURL, oidcServer.validClientID, oidcServer.validClientSecret, oidcServer.validRedirectURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.AJAXUnauth401 = true
+
+	protected := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r = r.WithContext(context.WithValue(r.Context(), oauth2.HTTPClient, oidcHTTPServer.Client()))
+		handler.Wrap(protected).ServeHTTP(w, r)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "application/json")
+	rr := httptest.NewRecorder()
+	wrapped.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+	if got := rr.Header().Get("Location"); got != "" {
+		t.Fatalf("Location = %q, want empty", got)
+	}
+}
+
 func TestServeLogin_storesReturnToAndRedirects(t *testing.T) {
 	oidcServer, oidcHTTPServer := startMockOIDCServer(t)
 	store := &memSessStore{}


### PR DESCRIPTION
Some cases might want to allow anonymous access, but allow elevation to logged in. Add support for this, with explicit calls for login/logout.

It's also not useful to redirect Ajax requests to login, as they don't surface to users. Add an option to 401 on these, so the frontend can handle it appropriately.